### PR TITLE
Changed admin password for cicd post-merge tests

### DIFF
--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/common/HttpClientFactory.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/common/HttpClientFactory.java
@@ -31,7 +31,7 @@ public class HttpClientFactory {
     public Client createClient() {
         Client client = ClientBuilder.newClient();
         client.property(ClientProperties.FOLLOW_REDIRECTS, true);
-        client.register(HttpAuthenticationFeature.basic("management/admin", "Pyi1bo1r"));
+        client.register(HttpAuthenticationFeature.basic("management/admin", "admin"));
         client.register(CumulocityJSONMessageBodyReader.class);
         return client;
     }


### PR DESCRIPTION
Check if the hard-coded admin password was causing problem in post-merge tests