### PR TITLE
[MTM-41282]: Upgrade spring-boot in microservice-sdk to 2.5.8

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -19,7 +19,7 @@
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
-        <spring-boot-dependencies.version>2.5.5</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.5.8</spring-boot-dependencies.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <guava.version>29.0-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>


### PR DESCRIPTION
To have at least 10.13 without any vulnerabilities