### PR TITLE
MTM-43763 fport appearing twice on response from Codec Microservice Encoding API

### DIFF
--- a/microservice/lpwan-custom-codec/src/main/java/com/cumulocity/microservice/lpwan/codec/encoder/model/LpwanEncoderResult.java
+++ b/microservice/lpwan-custom-codec/src/main/java/com/cumulocity/microservice/lpwan/codec/encoder/model/LpwanEncoderResult.java
@@ -8,6 +8,7 @@
 package com.cumulocity.microservice.lpwan.codec.encoder.model;
 
 import com.cumulocity.microservice.customencoders.api.model.EncoderResult;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +34,7 @@ public class LpwanEncoderResult extends EncoderResult {
      *
      * @return the f-port
      */
+    @JsonIgnore
     public @Null Integer getFport() {
         String fportstring = getPropertiesMap().get(FPORT_KEY);
         if (!Strings.isNullOrEmpty(fportstring)) {

--- a/microservice/lpwan-custom-codec/src/test/java/com/cumulocity/microservice/lpwan/codec/encoder/model/LpwanEncoderResultTest.java
+++ b/microservice/lpwan-custom-codec/src/test/java/com/cumulocity/microservice/lpwan/codec/encoder/model/LpwanEncoderResultTest.java
@@ -1,0 +1,37 @@
+package com.cumulocity.microservice.lpwan.codec.encoder.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LpwanEncoderResultTest {
+    @Test
+    public void fportShouldNotAppearTwiceOnSerialization() throws JsonProcessingException {
+        LpwanEncoderResult lpwanEncoderResult = new LpwanEncoderResult();
+        lpwanEncoderResult.setEncodedCommand("9F000000");
+        Map<String, String> properties = new HashMap<>();
+        properties.put("fport", "20");
+        lpwanEncoderResult.setProperties(properties);
+        lpwanEncoderResult.setSuccess(true);
+        lpwanEncoderResult.setMessage("Successfully Encoded the payload");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String outputJson = objectMapper.writeValueAsString(lpwanEncoderResult);
+        assertTrue(outputJson.contains("\"properties\":{\"fport\":\"20\"}"));
+        // Used to appear in form {"encodedCommand":"9F000000","properties":{"fport":"20"},"message":"Successfully Encoded the payload","success":true,"fport":20} when @JsonIgnore was missing
+        assertFalse(outputJson.contains(",\"fport\":20"));
+    }
+
+    @Test
+    public void deserializedObjectShouldHaveFPort() throws JsonProcessingException {
+        String inputJson = "{\"encodedCommand\":\"9F000000\",\"properties\":{\"fport\":\"20\"},\"message\":\"Successfully Encoded the payload\",\"success\":true}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        LpwanEncoderResult lpwanEncoderResult = objectMapper.readValue(inputJson, LpwanEncoderResult.class);
+        assertEquals(20, lpwanEncoderResult.getFport());
+    }
+}


### PR DESCRIPTION
JsonIgnore fport during serialization