### PR TITLE
MTM-41543: Microservice SDK now uses singleton APIs 

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/Platform.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/Platform.java
@@ -30,13 +30,14 @@ import com.cumulocity.sdk.client.identity.IdentityApi;
 import com.cumulocity.sdk.client.inventory.BinariesApi;
 import com.cumulocity.sdk.client.inventory.InventoryApi;
 import com.cumulocity.sdk.client.measurement.MeasurementApi;
+import com.cumulocity.sdk.client.messaging.notifications.NotificationSubscriptionApi;
+import com.cumulocity.sdk.client.messaging.notifications.TokenApi;
 import com.cumulocity.sdk.client.option.SystemOptionApi;
 import com.cumulocity.sdk.client.option.TenantOptionApi;
-import com.cumulocity.sdk.client.messaging.notifications.TokenApi;
 import com.cumulocity.sdk.client.user.UserApi;
-import com.cumulocity.sdk.client.messaging.notifications.NotificationSubscriptionApi;
 
-public interface Platform extends AutoCloseable{
+public interface Platform extends AutoCloseable {
+
     RestOperations rest();
 
     InventoryApi getInventoryApi() throws SDKException;

--- a/java-client/src/main/java/com/cumulocity/sdk/client/PlatformImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/PlatformImpl.java
@@ -44,18 +44,18 @@ import com.cumulocity.sdk.client.inventory.InventoryApi;
 import com.cumulocity.sdk.client.inventory.InventoryApiImpl;
 import com.cumulocity.sdk.client.measurement.MeasurementApi;
 import com.cumulocity.sdk.client.measurement.MeasurementApiImpl;
+import com.cumulocity.sdk.client.messaging.notifications.NotificationSubscriptionApi;
 import com.cumulocity.sdk.client.messaging.notifications.NotificationSubscriptionApiImpl;
+import com.cumulocity.sdk.client.messaging.notifications.TokenApi;
+import com.cumulocity.sdk.client.messaging.notifications.TokenApiImpl;
 import com.cumulocity.sdk.client.option.SystemOptionApi;
 import com.cumulocity.sdk.client.option.SystemOptionApiImpl;
 import com.cumulocity.sdk.client.option.TenantOptionApi;
 import com.cumulocity.sdk.client.option.TenantOptionApiImpl;
-import com.cumulocity.sdk.client.messaging.notifications.TokenApi;
-import com.cumulocity.sdk.client.messaging.notifications.TokenApiImpl;
 import com.cumulocity.sdk.client.user.UserApi;
 import com.cumulocity.sdk.client.user.UserApiImpl;
-import com.cumulocity.sdk.client.messaging.notifications.NotificationSubscriptionApi;
 
-public class PlatformImpl extends PlatformParameters implements Platform, AutoCloseable {
+public class PlatformImpl extends PlatformParameters implements Platform {
 
     private static final String PLATFORM_URL = "platform";
 
@@ -314,4 +314,5 @@ public class PlatformImpl extends PlatformParameters implements Platform, AutoCl
     public RestConnector rest() {
         return new RestConnector(this, new ResponseParser(this.getResponseMapper()));
     }
+
 }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
@@ -39,6 +39,7 @@ import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -98,10 +99,17 @@ public class RestConnector implements RestOperations {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (client != null) {
             client.close();
         }
+    }
+
+    public boolean isClosed() {
+        if (client instanceof JerseyClient) {
+            return ((JerseyClient) client).isClosed();
+        }
+        return false;
     }
 
     @Override

--- a/java-client/src/main/java/com/cumulocity/sdk/client/RestOperations.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/RestOperations.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Response;
 import java.io.InputStream;
 
 public interface RestOperations extends AutoCloseable {
+
     <T extends ResourceRepresentation> T get(String path, CumulocityMediaType mediaType, Class<T> responseType) throws SDKException;
 
     <T > T get(String path, MediaType mediaType, Class<T> responseType) throws SDKException;

--- a/java-email-client/src/main/java/com/cumulocity/email/client/EmailApiImpl.java
+++ b/java-email-client/src/main/java/com/cumulocity/email/client/EmailApiImpl.java
@@ -21,7 +21,7 @@ public class EmailApiImpl implements EmailApi {
 
     public int sendEmail(Email email) {
         try {
-            final String url = host + "email/emails/";
+            final String url = host + "/email/emails/";
             final Request request = Post(url).bodyString(defaultJSON().forValue(email), APPLICATION_JSON);
             final Response response = authorizedTemplate.execute(request);
             return response.returnResponse().getStatusLine().getStatusCode();

--- a/microservice/api/src/main/java/com/cumulocity/microservice/api/CumulocityClientProperties.java
+++ b/microservice/api/src/main/java/com/cumulocity/microservice/api/CumulocityClientProperties.java
@@ -1,0 +1,75 @@
+package com.cumulocity.microservice.api;
+
+import com.cumulocity.sdk.client.HttpClientConfig;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@ConfigurationProperties(prefix = "c8y")
+public class CumulocityClientProperties {
+
+    /**
+     * Client base URL (protocol, hostname & port).
+     */
+    private String baseURL;
+
+    /**
+     * (Optional) HTTP proxy host.
+     */
+    private String proxy;
+
+    /**
+     * (Optional) HTTP proxy port.
+     */
+    private int proxyPort;
+
+    /**
+     * In milliseconds, 0 = infinite.
+     */
+    private Integer httpReadTimeout;
+
+    @NestedConfigurationProperty
+    private HttpClientConfig httpclient = HttpClientConfig.httpConfig().build();
+
+    public String getBaseURL() {
+        return baseURL;
+    }
+
+    public void setBaseURL(String baseURL) {
+        this.baseURL = baseURL;
+    }
+
+    public String getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(String proxy) {
+        this.proxy = proxy;
+    }
+
+    public int getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(int proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    @Deprecated
+    @DeprecatedConfigurationProperty(replacement = "c8y.httpclient.httpReadTimeout")
+    public Integer getHttpReadTimeout() {
+        return httpReadTimeout;
+    }
+
+    public void setHttpReadTimeout(Integer httpReadTimeout) {
+        this.httpReadTimeout = httpReadTimeout;
+    }
+
+    public HttpClientConfig getHttpclient() {
+        return httpclient;
+    }
+
+    public void setHttpclient(HttpClientConfig httpclient) {
+        this.httpclient = httpclient;
+    }
+}

--- a/microservice/api/src/main/java/com/cumulocity/microservice/api/NoSuchPlatformBeanDefinitionFailureAnalyzer.java
+++ b/microservice/api/src/main/java/com/cumulocity/microservice/api/NoSuchPlatformBeanDefinitionFailureAnalyzer.java
@@ -1,0 +1,43 @@
+package com.cumulocity.microservice.api;
+
+import com.cumulocity.sdk.client.Platform;
+import com.cumulocity.sdk.client.PlatformParameters;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.boot.diagnostics.analyzer.AbstractInjectionFailureAnalyzer;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Detects missing {@link com.cumulocity.sdk.client.PlatformImpl PlatformImpl} or {@link PlatformParameters} beans
+ * and displays instructions for alternative approach.
+ */
+@Order(1)
+class NoSuchPlatformBeanDefinitionFailureAnalyzer extends AbstractInjectionFailureAnalyzer<NoSuchBeanDefinitionException> {
+
+    @Override
+    protected FailureAnalysis analyze(Throwable rootFailure, NoSuchBeanDefinitionException cause, String description) {
+        if (cause.getNumberOfBeansFound() != 0) {
+            return null;
+        }
+        ResolvableType beanType = cause.getResolvableType();
+        if (beanType == null) {
+            return null;
+        }
+        Class<?> resolvedType = beanType.resolve();
+        if (resolvedType == null) {
+            return null;
+        }
+        if (PlatformParameters.class.isAssignableFrom(resolvedType)) {
+            String desc = String.format("%s required a bean of type '%s' that could not be found.%n",
+                    (description != null) ? description : "A component", resolvedType.getName());
+            String action = String.format("Bean of this type is no longer available.%n" +
+                    "Instead inject platform APIs directly " +
+                    "or inject " + Platform.class.getName() + " and get the same platform APIs instances with getters.%n" +
+                    "Use relative URL's starting with '/' with RestConnector bean to have them resolved automatically " +
+                    "against the host defined in PlatformParameters#getHost().");
+            return new FailureAnalysis(desc, action, cause);
+        }
+        return null;
+    }
+}

--- a/microservice/api/src/main/resources/META-INF/spring.factories
+++ b/microservice/api/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=\
+com.cumulocity.microservice.api.NoSuchPlatformBeanDefinitionFailureAnalyzer

--- a/microservice/api/src/test/java/com/cumulocity/microservice/api/BaseHttpClientConfigTest.java
+++ b/microservice/api/src/test/java/com/cumulocity/microservice/api/BaseHttpClientConfigTest.java
@@ -1,43 +1,43 @@
 package com.cumulocity.microservice.api;
 
-import com.cumulocity.microservice.context.ContextServiceImpl;
+import com.cumulocity.microservice.context.ContextService;
 import com.cumulocity.microservice.context.credentials.MicroserviceCredentials;
 import com.cumulocity.microservice.context.credentials.UserCredentials;
 import com.cumulocity.sdk.client.HttpClientConfig;
-import com.cumulocity.sdk.client.PlatformImpl;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BaseHttpClientConfigTest {
 
     @Autowired
-    private CumulocityClientFeature cumulocityClientFeature;
+    ContextService<MicroserviceCredentials> microserviceContextService;
 
     @Autowired
-    @Qualifier("tenantPlatform")
-    private PlatformImpl tenantPlatform;
+    ContextService<UserCredentials> userContextService;
 
     @Autowired
-    @Qualifier("userPlatform")
-    private PlatformImpl userPlatform;
+    CumulocityClientProperties clientProperties;
+
+    @Autowired
+    CumulocityClientFeature.TenantPlatformConfig tenantPlatform;
+
+    @Autowired
+    CumulocityClientFeature.UserPlatformConfig userPlatform;
 
     protected void verifyHttpClientConfigBean(HttpClientConfig expectedHttpClientConfig) {
-        assertEquals(expectedHttpClientConfig, cumulocityClientFeature.httpClientConfig());
+        assertEquals(expectedHttpClientConfig, clientProperties.getHttpclient());
     }
 
     protected void verifyTenantPlatformHttpClientConfig(HttpClientConfig expectedHttpClientConfig) {
-        ContextServiceImpl<MicroserviceCredentials> microserviceCredentialsContextService = new ContextServiceImpl<>(MicroserviceCredentials.class);
-        microserviceCredentialsContextService.runWithinContext(new MicroserviceCredentials().withTenant("tenant1"), () -> {
-            assertEquals(expectedHttpClientConfig, tenantPlatform.getHttpClientConfig());
+        microserviceContextService.runWithinContext(new MicroserviceCredentials().withTenant("tenant1"), () -> {
+            assertEquals(expectedHttpClientConfig, tenantPlatform.getDelegate().getHttpClientConfig());
         });
     }
 
     protected void verifyUserPlatformHttpClientConfig(HttpClientConfig expectedHttpClientConfig) {
-        ContextServiceImpl<UserCredentials> userCredentialsContextService = new ContextServiceImpl<>(UserCredentials.class);
-        userCredentialsContextService.runWithinContext(new UserCredentials().withTenant("tenant2").withUsername("user2"), () -> {
-            assertEquals(expectedHttpClientConfig, userPlatform.getHttpClientConfig());
+        userContextService.runWithinContext(new UserCredentials().withTenant("tenant2").withUsername("user2"), () -> {
+            assertEquals(expectedHttpClientConfig, userPlatform.getDelegate().getHttpClientConfig());
         });
     }
 }

--- a/microservice/api/src/test/java/com/cumulocity/microservice/api/CumulocityClientFeatureTest.java
+++ b/microservice/api/src/test/java/com/cumulocity/microservice/api/CumulocityClientFeatureTest.java
@@ -1,0 +1,79 @@
+package com.cumulocity.microservice.api;
+
+import com.cumulocity.microservice.context.ContextService;
+import com.cumulocity.microservice.context.annotation.EnableContextSupport;
+import com.cumulocity.microservice.context.credentials.MicroserviceCredentials;
+import com.cumulocity.microservice.context.credentials.UserCredentials;
+import com.cumulocity.sdk.client.Platform;
+import com.cumulocity.sdk.client.RestOperations;
+import com.cumulocity.sdk.client.inventory.InventoryApi;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = EnableMicroservicePlatformApiConfiguration.class)
+@ConfigurationPropertiesScan
+@EnableContextSupport
+class CumulocityClientFeatureTest {
+
+    @Nested
+    class TenantPlatform {
+
+        @Autowired
+        ContextService<MicroserviceCredentials> tenantContext;
+
+        @Autowired
+        Platform tenantPlatform;
+
+        @Autowired
+        RestOperations tenantRestOperations;
+
+        @Autowired
+        InventoryApi tenantInventoryApi;
+
+        @Test
+        void shouldReturnSameInstanceOfAPIsAsAutowired() {
+            tenantContext.runWithinContext(new MicroserviceCredentials().withTenant("acme"), () -> {
+                assertThat(tenantPlatform.rest()).isNotSameAs(tenantRestOperations);
+                assertThat(tenantPlatform.getInventoryApi()).isSameAs(tenantInventoryApi);
+            });
+            tenantContext.runWithinContext(new MicroserviceCredentials().withTenant("meta"), () -> {
+                assertThat(tenantPlatform.rest()).isNotSameAs(tenantRestOperations);
+                assertThat(tenantPlatform.getInventoryApi()).isSameAs(tenantInventoryApi);
+            });
+        }
+    }
+
+    @Nested
+    class UserPlatform {
+
+        @Autowired
+        ContextService<UserCredentials> userContext;
+
+        @Autowired @Qualifier("userPlatform")
+        Platform userPlatform;
+
+        @Autowired @Qualifier("userRestConnector")
+        RestOperations userRestOperations;
+
+        @Autowired @Qualifier("userInventoryApi")
+        InventoryApi userInventoryApi;
+
+        @Test
+        void shouldReturnSameInstanceOfAPIsAsAutowired() {
+            userContext.runWithinContext(new UserCredentials().withTenant("acme").withUsername("john"), () -> {
+                assertThat(userPlatform.rest()).isNotSameAs(userRestOperations);
+                assertThat(userPlatform.getInventoryApi()).isSameAs(userInventoryApi);
+            });
+            userContext.runWithinContext(new UserCredentials().withTenant("acme").withUsername("jane"), () -> {
+                assertThat(userPlatform.rest()).isNotSameAs(userRestOperations);
+                assertThat(userPlatform.getInventoryApi()).isSameAs(userInventoryApi);
+            });
+        }
+    }
+}

--- a/microservice/api/src/test/java/com/cumulocity/microservice/api/NoSuchPlatformBeanDefinitionFailureAnalyzerTest.java
+++ b/microservice/api/src/test/java/com/cumulocity/microservice/api/NoSuchPlatformBeanDefinitionFailureAnalyzerTest.java
@@ -1,0 +1,61 @@
+package com.cumulocity.microservice.api;
+
+import com.cumulocity.microservice.context.annotation.EnableContextSupport;
+import com.cumulocity.sdk.client.PlatformImpl;
+import com.cumulocity.sdk.client.PlatformParameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+class NoSuchPlatformBeanDefinitionFailureAnalyzerTest {
+
+    NoSuchPlatformBeanDefinitionFailureAnalyzer analyzer = new NoSuchPlatformBeanDefinitionFailureAnalyzer();
+
+    @Test
+    void shouldAnalyzeMissingPlatformImpl() {
+        FailureAnalysis analysis = analyzer.analyze(createFailure(MissingPlatformImplContext.class));
+        assertThat(analysis.getDescription())
+                .contains("required a bean of type '" + PlatformImpl.class.getName() + "' that could not be found");
+    }
+
+    @Test
+    void shouldAnalyzeMissingPlatformParameters() {
+        FailureAnalysis analysis = analyzer.analyze(createFailure(MissingPlatformParametersContext.class));
+        assertThat(analysis.getDescription())
+                .contains("required a bean of type '" + PlatformParameters.class.getName() + "' that could not be found");
+    }
+
+    private BeanCreationException createFailure(Class<?> configClass) {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.register(configClass);
+            try {
+                context.refresh();
+            } catch (BeanCreationException e) {
+                return e;
+            }
+        }
+        return null;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableContextSupport
+    @EnableMicroservicePlatformApi
+    static class MissingPlatformImplContext {
+        @Autowired PlatformImpl platform;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableContextSupport
+    @EnableMicroservicePlatformApi
+    static class MissingPlatformParametersContext {
+        @Autowired PlatformParameters parameters;
+    }
+}

--- a/microservice/context/src/main/java/com/cumulocity/microservice/context/scope/DefaultScopeContainer.java
+++ b/microservice/context/src/main/java/com/cumulocity/microservice/context/scope/DefaultScopeContainer.java
@@ -2,9 +2,6 @@ package com.cumulocity.microservice.context.scope;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ObjectUtils;
-import org.springframework.util.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -104,21 +101,10 @@ public class DefaultScopeContainer implements ScopeContainer {
         }
         try {
             Object removed = objectsMap.remove(name);
-            doReleaseResource(removed);
             runDestructionCallbacks(name);
             return removed;
         } finally {
             objectsInDestruction.remove(name);
-        }
-    }
-
-    private void doReleaseResource(Object object) {
-        if (ClassUtils.isAssignableValue(AutoCloseable.class, object)) {
-            try {
-                ((AutoCloseable) object).close();
-            } catch (Exception e) {
-                log.debug("Could not release resources of: {}", object.getClass().getSimpleName());
-            }
         }
     }
 

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -74,6 +74,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${spring-boot-dependencies.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.vaadin.external.google</groupId>
+                        <artifactId>android-json</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/service/impl/RoleServiceImpl.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/service/impl/RoleServiceImpl.java
@@ -5,6 +5,7 @@ import com.cumulocity.rest.representation.user.CurrentUserRepresentation;
 import com.cumulocity.rest.representation.user.RoleRepresentation;
 import com.cumulocity.sdk.client.RestConnector;
 import com.cumulocity.sdk.client.SDKException;
+import com.cumulocity.sdk.client.user.UserApi;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
@@ -22,19 +23,18 @@ import static com.cumulocity.rest.representation.user.UserMediaType.CURRENT_USER
 @Slf4j
 @Service
 public class RoleServiceImpl implements RoleService {
-    private final RestConnector userRestConnector;
 
-    @Autowired
-    public RoleServiceImpl(RestConnector userRestConnector) {
-        this.userRestConnector = userRestConnector;
+    private final UserApi userApi;
+
+    public RoleServiceImpl(UserApi userApi) {
+        this.userApi = userApi;
     }
 
     @Override
     public List<String> getUserRoles() {
         final List<String> result = Lists.newArrayList();
         try {
-            final URL url = new URL(new URL(userRestConnector.getPlatformParameters().getHost()), "user/currentUser");
-            final CurrentUserRepresentation currrentUser = userRestConnector.get(url.toString(), CURRENT_USER, CurrentUserRepresentation.class);
+            final CurrentUserRepresentation currrentUser = userApi.getCurrentUser();
     
             final List<RoleRepresentation> effectiveRoles = currrentUser.getEffectiveRoles();
             if (effectiveRoles != null && !effectiveRoles.isEmpty()) {


### PR DESCRIPTION
Regardless if an API is returned from `Platform` getter or `@Autowired`, it is now the same instance.
This prevents resource leeks from non Spring managed instances returned from the `Platform` earlier.

Now using Spring built-in `Bean(destroyMethod = "close")` to release resources instead of custom support for `AutoClosable` inside `DefaultScopeContainer`. Scope responsibility is to call destruction callbacks registered by Spring Framework, regardless of the callback mechanism. It is up to the IoC container to register destruction callbacks and provide mans of defining them for bean definitions.

Switched `CumulocityClientFeature` configuration to `@ConfigurationProperties` fully (only using `@Value` to implement double fallback on `baseUrl`).

Added `FailureAnalyzer` to detect missing `PlatformParameters` beans and suggest solution.

Added `<exclude>` for duplicated `org.json.JSONObject` class on classpath to `spring-boot-starter-test` in `<dependencyManagement>`.