### PR TITLE
[MTM-38752]: RPM requires Java 11+

### DIFF
--- a/microservice/package/src/main/java/com/cumulocity/agent/packaging/BaseMicroserviceMojo.java
+++ b/microservice/package/src/main/java/com/cumulocity/agent/packaging/BaseMicroserviceMojo.java
@@ -239,7 +239,7 @@ public abstract class BaseMicroserviceMojo extends AbstractMojo {
         return resource;
     }
 
-    private String getJavaVersion() {
+    String getJavaVersion() {
         Pattern pattern = Pattern.compile("\\d+\\.?\\d*");
         Matcher matcher = pattern.matcher(javaRuntime);
 

--- a/microservice/package/src/main/java/com/cumulocity/agent/packaging/PackageMojo.java
+++ b/microservice/package/src/main/java/com/cumulocity/agent/packaging/PackageMojo.java
@@ -104,7 +104,7 @@ public class PackageMojo extends BaseMicroserviceMojo {
                         element("group", "C8Y/Agent"),
                         element("distribution", "Cumulocity GmbH " + currentYear()),
                         element("packager", "Cumulocity GmbH"),
-                        element("requires", element(name("require"), "java >= " + javaRuntime)),
+                        element("requires", element(name("require"), requireJava() +" >= " + javaRuntime)),
                         element("repackJars", String.valueOf(false)),
                         mappings(
                                 mapping(directory("/usr/lib/" + directory),
@@ -314,6 +314,13 @@ public class PackageMojo extends BaseMicroserviceMojo {
         resource.setIncludes(ImmutableList.of(file.getName()));
         resource.setExcludes(ImmutableList.<String>of());
         return resource;
+    }
+
+    private String requireJava() {
+        if ("8".equals(getJavaVersion())) {
+            return "java";
+        }
+        return "java-" + getJavaVersion();
     }
 
     private void addFileToZip(final ZipOutputStream zipOutputStream, final File file, String name) throws IOException {


### PR DESCRIPTION
java-11 and java-17 are not backward compatible
It means we cannot define dependency like `java >= 11`, it must be defined as `java-11 => 11` and for java-17: `java-17 >= 17`