### PR TITLE
MTM-44467 Random failures in unit test for java sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <lombok.version>1.18.20</lombok.version>
         <lombok-plugin.version>${lombok.version}.0</lombok-plugin.version>
         <microemu.version>2.0.4</microemu.version>
-        <mockito.version>3.10.0</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
         <slf4j.version>1.7.32</slf4j.version>
         <spring.version>5.3.16</spring.version>
         <svenson.version>1.5.8</svenson.version>
@@ -140,6 +140,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
                     <systemPropertyVariables>
                         <security.mode>disabled</security.mode>
                     </systemPropertyVariables>


### PR DESCRIPTION
- Allowed selfAttach so that ByteBuddy works (used by Mockito)
- For detailed information look at developer notes in related MTM-44467