### PR TITLE
DM-601 inventory api get managedObject count by filter function added

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApi.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApi.java
@@ -124,7 +124,7 @@ public interface InventoryApi {
      * @return count of managed objects matched by the filter
      * @throws SDKException             if the query failed
      */
-    Integer getManagedObjectsCountByFilter(InventoryFilter filter) throws SDKException;
+    Integer countManagedObjectsByFilter(InventoryFilter filter) throws SDKException;
 
     /**
      * Returns supported measurements of the Managed Object specified by its id

--- a/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApi.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApi.java
@@ -118,11 +118,12 @@ public interface InventoryApi {
     ManagedObjectCollection getManagedObjectsByFilter(InventoryFilter filter) throws SDKException;
 
     /**
-     * Gets the count of managed objects from the platform based on specified filter.
+     * Returns the count of managed objects from the platform based on specified filter.
      *
      * @param filter the filter criteria(s)
      * @return count of managed objects matched by the filter
      * @throws SDKException             if the query failed
+     * @throws IllegalArgumentException if filter is null
      */
     Integer countManagedObjectsByFilter(InventoryFilter filter) throws SDKException;
 

--- a/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApi.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApi.java
@@ -118,6 +118,15 @@ public interface InventoryApi {
     ManagedObjectCollection getManagedObjectsByFilter(InventoryFilter filter) throws SDKException;
 
     /**
+     * Gets the count of managed objects from the platform based on specified filter.
+     *
+     * @param filter the filter criteria(s)
+     * @return count of managed objects matched by the filter
+     * @throws SDKException             if the query failed
+     */
+    Integer getManagedObjectsCountByFilter(InventoryFilter filter) throws SDKException;
+
+    /**
      * Returns supported measurements of the Managed Object specified by its id
      *
      * @param id id of the managed object to search for

--- a/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApiImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApiImpl.java
@@ -109,7 +109,7 @@ public class InventoryApiImpl implements InventoryApi {
     @Override
     public Integer countManagedObjectsByFilter(InventoryFilter filter) throws SDKException {
         if (filter == null) {
-            return 0;
+            throw new IllegalArgumentException("Inventory filter cannot be null");
         }
         Map<String, String> params = filter.getQueryParams();
         String path = getMOCollectionUrl() + "/count";

--- a/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApiImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApiImpl.java
@@ -107,7 +107,7 @@ public class InventoryApiImpl implements InventoryApi {
     }
 
     @Override
-    public Integer getManagedObjectsCountByFilter(InventoryFilter filter) throws SDKException {
+    public Integer countManagedObjectsByFilter(InventoryFilter filter) throws SDKException {
         if (filter == null) {
             return 0;
         }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApiImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/inventory/InventoryApiImpl.java
@@ -107,6 +107,16 @@ public class InventoryApiImpl implements InventoryApi {
     }
 
     @Override
+    public Integer getManagedObjectsCountByFilter(InventoryFilter filter) throws SDKException {
+        if (filter == null) {
+            return 0;
+        }
+        Map<String, String> params = filter.getQueryParams();
+        String path = getMOCollectionUrl() + "/count";
+        return restConnector.get(urlProcessor.replaceOrAddQueryParam(path, params), MediaType.APPLICATION_JSON_TYPE, Integer.class);
+    }
+
+    @Override
     public SupportedMeasurementsRepresentation getSupportedMeasurements(GId sourceId) throws SDKException {
         validatePresent(sourceId);
         String path = getMOCollectionUrl() + "/" + sourceId.getValue() + "/supportedMeasurements";

--- a/java-client/src/test/java/com/cumulocity/sdk/client/inventory/InventoryApiImplTest.java
+++ b/java-client/src/test/java/com/cumulocity/sdk/client/inventory/InventoryApiImplTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 
 import static com.cumulocity.rest.representation.inventory.InventoryMediaType.MANAGED_OBJECT;
@@ -202,6 +203,43 @@ public class InventoryApiImplTest {
         assertThat(list, notNullValue());
 
     }
+
+    @Test
+    public void shouldCountMosByEmptyFilter() throws SDKException {
+        //Given
+        String expectedUrl = INVENTORY_COLLECTION_URL + "/count";
+        InventoryFilter filter = new InventoryFilter();
+
+        // When
+        inventoryApiResource.countManagedObjectsByFilter(filter);
+
+        // Then
+        verify(restConnector).get(expectedUrl, MediaType.APPLICATION_JSON_TYPE, Integer.class);
+    }
+
+    @Test
+    public void shouldCountMosByTypeFilter() throws SDKException {
+        //Given
+        String myType = "myType";
+        InventoryFilter filter = new InventoryFilter().byType(myType);
+        String expectedUrl = INVENTORY_COLLECTION_URL + "/count?type=myType";
+
+        // When
+        inventoryApiResource.countManagedObjectsByFilter(filter);
+
+        // Then
+        verify(restConnector).get(expectedUrl, MediaType.APPLICATION_JSON_TYPE, Integer.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenCountByFilterWithNullInput() throws SDKException {
+        // When
+        Throwable thrown = catchThrowable(() -> inventoryApiResource.countManagedObjectsByFilter(null));
+
+        // Then
+        assertThat(thrown, is(instanceOf(IllegalArgumentException.class)));
+    }
+
     private void givenRespondManagedObject(GId id) {
         ManagedObjectRepresentation mo = new ManagedObjectRepresentation();
         when(restConnector.get(contains(INVENTORY_COLLECTION_URL+"/"+ GId.asString(id)), eq(MANAGED_OBJECT), eq(ManagedObjectRepresentation.class)))


### PR DESCRIPTION
inventory/managedObjects/count endpoint exists since core version 9.11 (introduced with this task https://cumulocity.atlassian.net/browse/MTM-18228)
Adding function to InventoryApi that uses the endpoint.