### PR TITLE
MTM-44862: Use Spring Framework version 5.3.18 - 10.13 backport

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.16</version>
+			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -19,7 +19,7 @@
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
-        <spring-boot-dependencies.version>2.5.8</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.5.12</spring-boot-dependencies.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
         <microemu.version>2.0.4</microemu.version>
         <mockito.version>3.12.4</mockito.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <spring.version>5.2.9.RELEASE</spring.version>
+        <spring.version>${spring-framework.version}</spring.version><!-- deprecated, use spring-framework.version instead -->
+        <spring-framework.version>5.2.20.RELEASE</spring-framework.version>
         <spring.security.version>5.3.9.RELEASE</spring.security.version>
         <svenson.version>1.5.8</svenson.version>
         <osgi.svenson.version>${svenson.version}-${cumulocity.core.version}</osgi.svenson.version>
@@ -440,6 +441,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>${spring-framework.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -586,7 +588,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>${spring.version}</version>
+                <version>${spring-framework.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
MTM-44862: Use Spring Framework version 5.3.18, which address the RCE vulnerability.