### PR TITLE
MTM-44862: Use Spring Framework version 5.3.18 - 10.11 backport

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -21,7 +21,7 @@
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
         <spring-boot-dependencies.version>2.2.10.RELEASE</spring-boot-dependencies.version>
-        <spring-framework.version>5.3.15</spring-framework.version>
+        <spring-framework.version>5.3.18</spring-framework.version>
         <spring-security.version>5.6.1</spring-security.version>
         <jetty.version>9.4.31.v20200723</jetty.version>
         <guava.version>29.0-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <microemu.version>2.0.4</microemu.version>
         <mockito.version>3.12.4</mockito.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <spring.version>5.3.15</spring.version>
+        <spring.version>5.3.18</spring.version>
         <spring.security.version>5.6.1</spring.security.version>
         <svenson.version>1.5.8</svenson.version>
         <osgi.svenson.version>${svenson.version}-${cumulocity.core.version}</osgi.svenson.version>


### PR DESCRIPTION
MTM-44862: Use Spring Framework version 5.3.18, which address the RCE vulnerability.