### PR TITLE
MTM-44862: Use Spring Framework version 5.2.20 - 10.10 backport

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -21,6 +21,7 @@
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
         <spring-boot-dependencies.version>2.2.10.RELEASE</spring-boot-dependencies.version>
+        <spring-framework.version>5.2.20.RELEASE</spring-framework.version>
         <jetty.version>9.4.31.v20200723</jetty.version>
         <guava.version>29.0-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
@@ -74,6 +75,15 @@
                 <scope>import</scope>
                 <type>pom</type>
                 <version>${jersey.version}</version>
+            </dependency>
+
+            <!-- override vulnerable spring version -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- spring boot -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <mockito.version>3.3.3</mockito.version>
         <powermock.version>1.7.4</powermock.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <spring.version>5.2.8.RELEASE</spring.version>
+        <spring.version>5.2.20.RELEASE</spring.version>
         <spring.security.version>5.3.4.RELEASE</spring.security.version>
         <svenson.version>1.5.8</svenson.version>
         <osgi.svenson.version>${svenson.version}-${cumulocity.core.version}</osgi.svenson.version>


### PR DESCRIPTION
MTM-44862: Use Spring Framework version 5.2.20, which address the RCE vulnerability.