### PR TITLE
MTM-43703 made_jwt_cache_validity_editable_by_tennant_option

### DIFF
--- a/microservice/security/pom.xml
+++ b/microservice/security/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.nsn.cumulocity.clients-java</groupId>
+            <artifactId>microservice-settings</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/annotation/TokenCacheConfiguration.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/annotation/TokenCacheConfiguration.java
@@ -2,21 +2,57 @@ package com.cumulocity.microservice.security.annotation;
 
 import com.cumulocity.microservice.security.token.JwtAuthenticatedTokenCache;
 import com.cumulocity.microservice.security.token.JwtTokenAuthenticationGuavaCache;
+import com.cumulocity.microservice.settings.annotation.EnableTenantOptionSettingsConfiguration;
+import com.cumulocity.microservice.settings.service.MicroserviceSettingsService;
+import com.google.common.primitives.Ints;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Optional;
+
 @Slf4j
 @Configuration
+@AutoConfigureAfter(EnableTenantOptionSettingsConfiguration.class)
 public class TokenCacheConfiguration {
+
+    private final Optional<MicroserviceSettingsService> settingsService;
+
+    public TokenCacheConfiguration(Optional<MicroserviceSettingsService> settingsService) {
+        this.settingsService = settingsService;
+    }
 
     @Bean
     @ConditionalOnMissingBean
-    public JwtAuthenticatedTokenCache jwtAuthenticatedTokenCache(@Value("${cache.guava.maxSize:10000}") int jwtGuavaCacheMaxSize, @Value("${cache.guava.expireAfterAccessInMinutes:10}") int jwtGuavaCacheExpireAfterAccessInMinutes) {
-        log.info("Default Guava implementation for token cache is used.\nParameters:\n- max cache size: " + jwtGuavaCacheMaxSize + "\n- expire after access: " + jwtGuavaCacheExpireAfterAccessInMinutes + " minutes");
-        return new JwtTokenAuthenticationGuavaCache(jwtGuavaCacheMaxSize, jwtGuavaCacheExpireAfterAccessInMinutes);
+    public JwtAuthenticatedTokenCache jwtAuthenticatedTokenCache(
+            @Value("${cache.guava.maxSize:10000}") int jwtGuavaCacheMaxSize,
+            @Value("${cache.guava.expireAfterAccessInMinutes:10}") int jwtGuavaCacheExpireAfterAccess,
+            @Value("${jwt.cache.guava.expireInSeconds:0}") int jwtCacheExpireInSeconds) {
+
+        int cacheMaxSize = settingsService
+                .map(it -> it.get("cache.guava.maxSize"))
+                .map(Ints::tryParse)
+                .orElse(jwtGuavaCacheMaxSize);
+
+        int cacheExpireAfterAccess = settingsService
+                .map(it -> it.get("cache.guava.expireAfterAccessInMinutes"))
+                .map(Ints::tryParse)
+                .orElse(jwtGuavaCacheExpireAfterAccess);
+
+        int jwtCacheExpire = settingsService
+                .map(it -> it.get("jwt.cache.guava.expireInSeconds"))
+                .map(Ints::tryParse)
+                .orElse(jwtCacheExpireInSeconds);
+
+        log.info("Default Guava implementation for token cache is used.\nParameters:\n- max cache size: "
+                + cacheMaxSize
+                + "\n- expire after access: " + cacheExpireAfterAccess + " minutes. Expire after write "
+                + jwtCacheExpire + " seconds");
+
+        return new JwtTokenAuthenticationGuavaCache(cacheMaxSize, cacheExpireAfterAccess, jwtCacheExpire);
     }
 }
 

--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/token/JwtTokenAuthenticationGuavaCache.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/token/JwtTokenAuthenticationGuavaCache.java
@@ -12,16 +12,21 @@ public class JwtTokenAuthenticationGuavaCache implements JwtAuthenticatedTokenCa
 
     private final Cache<JwtCredentials, Authentication> userTokenCache;
 
-    public JwtTokenAuthenticationGuavaCache(int maximumSize, int expireAfterAccessInMinutes) {
-        this.userTokenCache = CacheBuilder.newBuilder()
+    public JwtTokenAuthenticationGuavaCache(int maximumSize, int expireAfterAccessInMinutes, int jwtCacheExpireAfterWrite) {
+        CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder()
                 .maximumSize(maximumSize)
-                .expireAfterAccess(expireAfterAccessInMinutes, TimeUnit.MINUTES)
-                .build();
+                .expireAfterAccess(expireAfterAccessInMinutes, TimeUnit.MINUTES);
+
+        if(jwtCacheExpireAfterWrite > 0){
+            builder.expireAfterWrite(jwtCacheExpireAfterWrite, TimeUnit.SECONDS);
+        }
+
+        this.userTokenCache = builder.build();
     }
 
     @Override
-    public Authentication get(JwtCredentials key, JwtTokenAuthenticationLoader valueLoader) throws ExecutionException {
-        return userTokenCache.get(key, valueLoader);
+    public Authentication get(JwtCredentials key, JwtTokenAuthenticationLoader jwtTokenAuthenticationLoader) throws ExecutionException {
+        return userTokenCache.get(key, jwtTokenAuthenticationLoader);
     }
 }
 

--- a/microservice/security/src/main/resources/application.properties
+++ b/microservice/security/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 cache.guava.maxSize=10000
 cache.guava.expireAfterAccessInMinutes=10
+jwt.cache.guava.expireInSeconds=0


### PR DESCRIPTION
- needed to make cache validity shorter to match behawiour when basic is used
- for heavy used microservices this can be left with longer values
- added option to set expiration after wrtie in seconds