### PR TITLE
MTM-45152 fix randomly failing test

### DIFF
--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/common/Subscribers.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/common/Subscribers.java
@@ -7,7 +7,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class Subscribers {
 
-    public static <T> RealtimeNotificationSubscriber getSubscriberForType(Class<T> type, PlatformParameters platform) {
-        return new RealtimeNotificationSubscriber(platform, type);
+    public static <T> RealtimeNotificationSubscriber<T> getSubscriberForType(Class<T> type, PlatformParameters platform) {
+        return new RealtimeNotificationSubscriber<>(platform, type);
     }
 }

--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/common/TestSubscriptionListener.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/common/TestSubscriptionListener.java
@@ -5,18 +5,25 @@ import com.cumulocity.sdk.client.notification.SubscribeOperationListener;
 import com.cumulocity.sdk.client.notification.Subscription;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 public class TestSubscriptionListener<T> implements SubscribeOperationListener, com.cumulocity.sdk.client.notification.SubscriptionListener<String, T> {
     private boolean subscribed = false;
-    private T notification;
+    private final List<T> notifications = new ArrayList<>();
+
+    public T getNotification() {
+        return notifications.get(0);
+    }
 
     public boolean notificationReceived() {
-        return notification != null;
+        return !notifications.isEmpty();
     }
 
     @Override
     public void onNotification(Subscription<String> subscription, T received) {
-        this.notification = received;
+        this.notifications.add(received);
     }
 
     @Override


### PR DESCRIPTION
The issue is that test is subscribing to all managed object notifications so we can receive notification from different managed objects and for different actions. The fix is to find a specific notification we want to verify.