### PR TITLE
[MTM-44368] Microservice security: context Provider should correctly …

### DIFF
--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtils.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtils.java
@@ -4,7 +4,7 @@ import org.bouncycastle.util.encoders.Base64;
 import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
@@ -12,7 +12,6 @@ public class HttpRequestUtils {
     public static final String X_CUMULOCITY_APPLICATION_KEY = "X-Cumulocity-Application-Key";
     public static final String TFA_TOKEN_HEADER = "TFAToken";
     public static final String LOGIN_SEPARATOR = "/";
-    public static final String AUTH_ENCODING = "ASCII";
     public static final String AUTH_PREFIX = "BASIC ";
     public static final String AUTH_SEPARATOR = ":";
     public static final String XSRF_TOKEN_HEADER = "X-XSRF-TOKEN";
@@ -162,10 +161,8 @@ public class HttpRequestUtils {
     }
 
     public static String[] decode(String authorization) {
-        try {
-            return new String(Base64.decode(authorization.substring(AUTH_PREFIX.length()).getBytes()), AUTH_ENCODING).split(AUTH_SEPARATOR, 2);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        final byte[] decoded = Base64.decode(authorization.substring(AUTH_PREFIX.length()).getBytes());
+        return new String(decoded, StandardCharsets.UTF_8)
+                .split(AUTH_SEPARATOR, 2);
     }
 }

--- a/microservice/security/src/test/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtilsTest.java
+++ b/microservice/security/src/test/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtilsTest.java
@@ -6,17 +6,17 @@ import org.junit.jupiter.api.Test;
 class HttpRequestUtilsTest {
 
     //Base 64 credentials coded: "management/rtanaka@hks-power.co.jp:(Def_Leppard)1"
-    private static final  String asciiCharactersCredentials = "Basic bWFuYWdlbWVudC9ydGFuYWthQGhrcy1wb3dlci5jby5qcDooRGVmX0xlcHBhcmQpMQ==";
+    private static final  String ASCII_CHARACTERS_CREDENTIALS = "Basic bWFuYWdlbWVudC9ydGFuYWthQGhrcy1wb3dlci5jby5qcDooRGVmX0xlcHBhcmQpMQ==";
 
     //Base 64 credentials coded: "management/田中隆太:(Def_Leppard)1"
-    private static final  String notAsciiCharactersCredentials = "Basic bWFuYWdlbWVudC/nlLDkuK3pmoblpKo6KERlZl9MZXBwYXJkKTE=";
+    private static final  String NOT_ASCII_CHARACTERS_CREDENTIALS = "Basic bWFuYWdlbWVudC/nlLDkuK3pmoblpKo6KERlZl9MZXBwYXJkKTE=";
 
     @Test
     void shouldDecodeAsciiCharactersCredentials() {
         // Given
         final String[] expectedArguments = {"management/rtanaka@hks-power.co.jp", "(Def_Leppard)1"};
         // When
-        final String[] decoded = HttpRequestUtils.decode(asciiCharactersCredentials);
+        final String[] decoded = HttpRequestUtils.decode(ASCII_CHARACTERS_CREDENTIALS);
         // Then
         Assertions.assertArrayEquals(expectedArguments, decoded);
     }
@@ -26,7 +26,7 @@ class HttpRequestUtilsTest {
         // Given
         final String[] expectedArguments = {"management/田中隆太", "(Def_Leppard)1"};
         // When
-        final String[] decoded = HttpRequestUtils.decode(notAsciiCharactersCredentials);
+        final String[] decoded = HttpRequestUtils.decode(NOT_ASCII_CHARACTERS_CREDENTIALS);
         // Then
         Assertions.assertArrayEquals(expectedArguments, decoded);
 

--- a/microservice/security/src/test/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtilsTest.java
+++ b/microservice/security/src/test/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtilsTest.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 class HttpRequestUtilsTest {
 
     //Base 64 credentials coded: "management/rtanaka@hks-power.co.jp:(Def_Leppard)1"
-    private final static String asciiCharactersCredentials = "Basic bWFuYWdlbWVudC9ydGFuYWthQGhrcy1wb3dlci5jby5qcDooRGVmX0xlcHBhcmQpMQ==";
+    private static final  String asciiCharactersCredentials = "Basic bWFuYWdlbWVudC9ydGFuYWthQGhrcy1wb3dlci5jby5qcDooRGVmX0xlcHBhcmQpMQ==";
 
     //Base 64 credentials coded: "management/田中隆太:(Def_Leppard)1"
-    private final static String notAsciiCharactersCredentials = "Basic bWFuYWdlbWVudC/nlLDkuK3pmoblpKo6KERlZl9MZXBwYXJkKTE=";
+    private static final  String notAsciiCharactersCredentials = "Basic bWFuYWdlbWVudC/nlLDkuK3pmoblpKo6KERlZl9MZXBwYXJkKTE=";
 
     @Test
     void shouldDecodeAsciiCharactersCredentials() {

--- a/microservice/security/src/test/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtilsTest.java
+++ b/microservice/security/src/test/java/com/cumulocity/microservice/security/filter/util/HttpRequestUtilsTest.java
@@ -1,0 +1,34 @@
+package com.cumulocity.microservice.security.filter.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestUtilsTest {
+
+    //Base 64 credentials coded: "management/rtanaka@hks-power.co.jp:(Def_Leppard)1"
+    private final static String asciiCharactersCredentials = "Basic bWFuYWdlbWVudC9ydGFuYWthQGhrcy1wb3dlci5jby5qcDooRGVmX0xlcHBhcmQpMQ==";
+
+    //Base 64 credentials coded: "management/田中隆太:(Def_Leppard)1"
+    private final static String notAsciiCharactersCredentials = "Basic bWFuYWdlbWVudC/nlLDkuK3pmoblpKo6KERlZl9MZXBwYXJkKTE=";
+
+    @Test
+    void shouldDecodeAsciiCharactersCredentials() {
+        // Given
+        final String[] expectedArguments = {"management/rtanaka@hks-power.co.jp", "(Def_Leppard)1"};
+        // When
+        final String[] decoded = HttpRequestUtils.decode(asciiCharactersCredentials);
+        // Then
+        Assertions.assertArrayEquals(expectedArguments, decoded);
+    }
+
+    @Test
+    void shouldDecodeNoAsciiCharactersCredentials() {
+        // Given
+        final String[] expectedArguments = {"management/田中隆太", "(Def_Leppard)1"};
+        // When
+        final String[] decoded = HttpRequestUtils.decode(notAsciiCharactersCredentials);
+        // Then
+        Assertions.assertArrayEquals(expectedArguments, decoded);
+
+    }
+}


### PR DESCRIPTION
Microservice security: context Provider should correctly support not ASCII characters in the authorization header.