### PR TITLE
[MTM-45251] more logging for "Failed to parse error message"

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
@@ -52,7 +52,9 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.cumulocity.sdk.client.util.StringUtils.isNotBlank;
 import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
@@ -118,9 +120,15 @@ public class RestConnector implements RestOperations {
             Response response = getClientResponse(path, mediaType);
             return responseParser.parse(response, responseType, OK.getStatusCode());
         } catch (SDKException e) {
-              log.error(" request : GET {} for tenant: {} user: {}", path, platformParameters.getTenantId(), platformParameters.getUser());
+            logTenantUserMediaParameter(mediaType);
             throw e;
         }
+    }
+
+    private void logTenantUserMediaParameter(MediaType mediaType) {
+        Map<String, String> mediaTypeParameters = mediaType.getParameters();
+        String mediaParameterUncasted = mediaTypeParameters.entrySet().stream().map(entry -> entry.getKey() + ":" + entry.getValue()).collect(Collectors.joining("&"));
+        log.error("Exception happened for tenant: {} user: {} with mediaParameterUncasted : {} ", platformParameters.getTenantId(), platformParameters.getUser(), mediaParameterUncasted);
     }
 
     @Override
@@ -235,7 +243,7 @@ public class RestConnector implements RestOperations {
             Response response = httpPut(path, mediaType, representation);
             return parseResponseWithId(representation, response, OK.getStatusCode());
         } catch (SDKException e) {
-            log.error(" request : PUT {} for tenant: {} user: {}", path, platformParameters.getTenantId(), platformParameters.getUser());
+            logTenantUserMediaParameter(mediaType);
             throw e;
         }
     }
@@ -287,7 +295,7 @@ public class RestConnector implements RestOperations {
             response = httpPost(path, mediaType, mediaType, representation);
             return parseResponseWithId(representation, response, CREATED.getStatusCode());
         } catch (SDKException e) {
-            log.error(" request : POSTT {} for tenant: {} user: {}", path, platformParameters.getTenantId(), platformParameters.getUser());
+            logTenantUserMediaParameter(mediaType);
             throw e;
         }
     }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
@@ -114,8 +114,13 @@ public class RestConnector implements RestOperations {
 
     @Override
     public <T extends ResourceRepresentation> T get(String path, CumulocityMediaType mediaType, Class<T> responseType) throws SDKException {
-        Response response = getClientResponse(path, mediaType);
-        return responseParser.parse(response, responseType, OK.getStatusCode());
+        try {
+            Response response = getClientResponse(path, mediaType);
+            return responseParser.parse(response, responseType, OK.getStatusCode());
+        } catch (SDKException e) {
+              log.error(" request : GET {} for tenant: {} user: {}", path, platformParameters.getTenantId(), platformParameters.getUser());
+            throw e;
+        }
     }
 
     @Override
@@ -226,8 +231,13 @@ public class RestConnector implements RestOperations {
 
     @Override
     public <T extends ResourceRepresentationWithId> T put(String path, MediaType mediaType, T representation) throws SDKException {
-        Response response = httpPut(path, mediaType, representation);
-        return parseResponseWithId(representation, response, OK.getStatusCode());
+        try {
+            Response response = httpPut(path, mediaType, representation);
+            return parseResponseWithId(representation, response, OK.getStatusCode());
+        } catch (SDKException e) {
+            log.error(" request : PUT {} for tenant: {} user: {}", path, platformParameters.getTenantId(), platformParameters.getUser());
+            throw e;
+        }
     }
 
     private <T extends ResourceRepresentationWithId> T parseResponseWithId(T representation, Response response, int responseCode)
@@ -272,8 +282,14 @@ public class RestConnector implements RestOperations {
 
     @Override
     public <T extends ResourceRepresentationWithId> T post(String path, MediaType mediaType, T representation) throws SDKException {
-        Response response = httpPost(path, mediaType, mediaType, representation);
-        return parseResponseWithId(representation, response, CREATED.getStatusCode());
+        Response response = null;
+        try {
+            response = httpPost(path, mediaType, mediaType, representation);
+            return parseResponseWithId(representation, response, CREATED.getStatusCode());
+        } catch (SDKException e) {
+            log.error(" request : POSTT {} for tenant: {} user: {}", path, platformParameters.getTenantId(), platformParameters.getUser());
+            throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
Analyzing SDK-Exception in multi tenant microservices like smartrule miss additional information. when an Exception is thrown.

The timestamp is often not sufficient in cases when other microservices are involved. 
Analyzing the corresponding blocker with only timestamps and without tenant id was time consuming.