### PR TITLE
[MTM-45251] Extend Exception with tenant, user and ResponseHeader

### DIFF
--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/cep/CepApiIT.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/cep/CepApiIT.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -14,6 +15,8 @@ import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+//Disabled till fixing https://cumulocity.atlassian.net/browse/MTM-46135
+@Disabled
 public class CepApiIT extends JavaSdkITBase {
 
     final CepApi cepApi = platform.getCepApi();

--- a/java-client/src/main/java/com/cumulocity/sdk/client/PlatformImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/PlatformImpl.java
@@ -312,7 +312,7 @@ public class PlatformImpl extends PlatformParameters implements Platform {
 
     @Override
     public RestConnector rest() {
-        return new RestConnector(this, new ResponseParser(this.getResponseMapper()));
+        return new RestConnector(this, new ResponseParser(this.getResponseMapper(), this));
     }
 
 }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/PlatformParameters.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/PlatformParameters.java
@@ -124,7 +124,7 @@ public class PlatformParameters implements AutoCloseable {
         if (restConnector == null) {
             synchronized (lock) {
                 if (restConnector == null) {
-                    restConnector = new RestConnector(this, new ResponseParser(responseMapper));
+                    restConnector = new RestConnector(this, new ResponseParser(responseMapper, this));
                 }
             }
         }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/ResponseParser.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/ResponseParser.java
@@ -24,18 +24,15 @@ import com.cumulocity.model.idtype.GId;
 import com.cumulocity.rest.representation.ErrorMessageRepresentation;
 import com.cumulocity.rest.representation.ResourceRepresentation;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class ResponseParser {
@@ -93,11 +90,14 @@ public class ResponseParser {
             Map<String, List<String>> responseHeadermap = response.getStringHeaders();
             if (responseHeadermap != null) {
                 for (Map.Entry<String, List<String>> entry : responseHeadermap.entrySet()) {
-                    responseHeader += entry.getKey() +
-                            ": " + entry.getValue() +"\n";
+                    if (entry.getKey().equals("Forwarded")
+                            || entry.getKey().equals("Location")
+                            || entry.getKey().equals("Via")) {
+                        responseHeader += entry.getKey() +
+                                ": " + entry.getValue() + "\n";
+                    }
                 }
             }
-//            responseHeader = response.getStringHeaders().entrySet().stream().map(e -> e.getKey() + " = " + e.getValue()).collect(Collectors.joining("&"));
             errorMessage += "\n" + errorRepresentation;
         }
         if (platformParameters != null) {

--- a/java-client/src/test/java/com/cumulocity/sdk/client/ResponseParserTest.java
+++ b/java-client/src/test/java/com/cumulocity/sdk/client/ResponseParserTest.java
@@ -19,34 +19,27 @@
  */
 package com.cumulocity.sdk.client;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.when;
-
-import java.net.URI;
-
-import javax.ws.rs.core.MediaType;
-
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
-import org.apache.http.entity.ContentType;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.protocol.HTTP;
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.BaseResourceRepresentation;
+import com.cumulocity.rest.representation.ErrorMessageRepresentation;
+import com.cumulocity.rest.representation.inventory.InventoryRepresentation;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.cumulocity.model.idtype.GId;
-import com.cumulocity.rest.representation.BaseResourceRepresentation;
-import com.cumulocity.rest.representation.ErrorMessageRepresentation;
-import com.cumulocity.rest.representation.inventory.InventoryRepresentation;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.when;
 
 public class ResponseParserTest {
 
@@ -113,13 +106,14 @@ public class ResponseParserTest {
     }
 
     @Test
-    public void shouldIncludeResponseHeaderInExceptionWhenStatusIsNotAsExpected() {
+    public void shouldIncludeSpecificResponseHeaderInExceptionWhenStatusIsNotAsExpected() {
         // Given
         when(response.getStatus()).thenReturn(ERROR_STATUS);
         ErrorMessageRepresentation errorRepresentation = new ErrorMessageRepresentation();
         when(response.hasEntity()).thenReturn(true);
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.add("Content-Type", "application/json");
+        headers.add("Location", "en.wikipedia.org:8080");
         headers.add("x-authorization", "1bdc5db0-dfc8-43f2-9159-3827bfe48ea7.1587315996051");
         when(response.getStringHeaders()).thenReturn(headers);
         when(response.readEntity(ErrorMessageRepresentation.class)).thenReturn(errorRepresentation);
@@ -129,7 +123,11 @@ public class ResponseParserTest {
 
         // Then
         Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
-                .hasMessageContaining("Content-Type: [application/json]" );
+                .hasMessageContaining("Location: [en.wikipedia.org:8080]");
+        Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
+                .hasMessageNotContaining("Content-Type: [application/json]");
+        Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
+                .hasMessageNotContaining("x-authorization");
     }
 
     @Test

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.100.0</revision>
-        <changelist></changelist>
+        <revision>1014.101.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.111.0</revision>
-        <changelist></changelist>
+        <revision>1014.112.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.101.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.106.0</revision>
-        <changelist></changelist>
+        <revision>1014.107.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.102.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.107.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.103.0</revision>
-        <changelist></changelist>
+        <revision>1014.104.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.111.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.98.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.103.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.101.0</revision>
-        <changelist></changelist>
+        <revision>1014.102.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.112.0</revision>
-        <changelist></changelist>
+        <revision>1014.113.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.110.0</revision>
-        <changelist></changelist>
+        <revision>1014.111.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.104.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.105.0</revision>
-        <changelist></changelist>
+        <revision>1014.106.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.107.0</revision>
-        <changelist></changelist>
+        <revision>1014.108.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.98.0</revision>
-        <changelist></changelist>
+        <revision>1014.99.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.99.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.104.0</revision>
-        <changelist></changelist>
+        <revision>1014.105.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.113.0</revision>
-        <changelist></changelist>
+        <revision>1014.114.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.105.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.108.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.109.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.113.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.108.0</revision>
-        <changelist></changelist>
+        <revision>1014.109.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.106.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.99.0</revision>
-        <changelist></changelist>
+        <revision>1014.100.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.100.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.112.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <revision>1014.110.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.102.0</revision>
-        <changelist></changelist>
+        <revision>1014.103.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -8,8 +8,8 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>1014.109.0</revision>
-        <changelist></changelist>
+        <revision>1014.110.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <java.version>1.8</java.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
+++ b/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
@@ -12,10 +12,7 @@ import com.cumulocity.sdk.client.util.StringUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.apache.commons.lang.StringEscapeUtils;
 
 import javax.validation.constraints.NotBlank;
@@ -34,15 +31,21 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
+@RequiredArgsConstructor
 public abstract class LnsConnection {
 
     @NotBlank
     @JsonView(LnsConnection.PublicView.class)
+    @NonNull
     private String name;
 
     @JsonView(LnsConnection.PublicView.class)
+    @NonNull
     private String description;
+
+    @JsonIgnore
+    @Setter(AccessLevel.PROTECTED)
+    private boolean connectionReachable;
 
     // JSON View interface for tagging Publicly visible fields
     public interface PublicView {}
@@ -101,5 +104,11 @@ public abstract class LnsConnection {
      * @param lnsConnectionWithNewData LNS Connection with updated data
      */
     protected abstract void update(@NotNull LnsConnection lnsConnectionWithNewData);
+
+    /**
+     * Implementors are expected to check if the connection is valid (by checking the session)
+     * @return true if the LNS connection is valid/reachable.
+     */
+    public abstract boolean checkConnectionStatus();
 }
 

--- a/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
+++ b/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
@@ -31,21 +31,23 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@RequiredArgsConstructor
 public abstract class LnsConnection {
 
     @NotBlank
     @JsonView(LnsConnection.PublicView.class)
-    @NonNull
     private String name;
 
     @JsonView(LnsConnection.PublicView.class)
-    @NonNull
     private String description;
 
     @JsonIgnore
     @Setter(AccessLevel.PROTECTED)
     private boolean connectionReachable;
+
+    public LnsConnection(String name, String description){
+        this.name = name;
+        this.description = description;
+    }
 
     // JSON View interface for tagging Publicly visible fields
     public interface PublicView {}

--- a/lpwan-backend/src/main/java/com/cumulocity/lpwan/platform/repository/LpwanRepository.java
+++ b/lpwan-backend/src/main/java/com/cumulocity/lpwan/platform/repository/LpwanRepository.java
@@ -1,0 +1,120 @@
+package com.cumulocity.lpwan.platform.repository;
+
+import com.cumulocity.lpwan.lns.connection.model.LnsConnectionDeserializer;
+import com.cumulocity.microservice.context.inject.TenantScope;
+import com.cumulocity.model.ID;
+import com.cumulocity.model.event.CumulocityAlarmStatuses;
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.alarm.AlarmRepresentation;
+import com.cumulocity.rest.representation.identity.ExternalIDRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.sdk.client.SDKException;
+import com.cumulocity.sdk.client.alarm.AlarmApi;
+import com.cumulocity.sdk.client.alarm.AlarmCollection;
+import com.cumulocity.sdk.client.alarm.AlarmFilter;
+import com.cumulocity.sdk.client.identity.IdentityApi;
+import com.cumulocity.sdk.client.inventory.InventoryApi;
+import com.google.common.base.Supplier;
+import com.google.common.collect.FluentIterable;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static com.cumulocity.model.event.CumulocityAlarmStatuses.*;
+
+@Component
+@TenantScope
+public class LpwanRepository {
+
+    public static final String MICROSERVICE_ID_TYPE = "c8y_Microservice";
+    public static final String ALARM_TYPE = "c8y_ProviderAccessAlarm";
+    public static final String CRITICAL = "CRITICAL";
+
+    @Autowired
+    private IdentityApi identityApi;
+
+    @Autowired
+    private AlarmApi alarmApi;
+
+    @Autowired
+    private InventoryApi inventoryApi;
+
+    public GId findOrCreateSource() {
+        return findGId(MICROSERVICE_ID_TYPE, LnsConnectionDeserializer.getRegisteredAgentName()).or(new Supplier<GId>() {
+            public GId get() {
+                final GId source = createManagedObject(MICROSERVICE_ID_TYPE, LnsConnectionDeserializer.getRegisteredAgentName());
+                createExternalId(source, MICROSERVICE_ID_TYPE, LnsConnectionDeserializer.getRegisteredAgentName());
+                return source;
+            }
+        });
+    }
+
+    public ExternalIDRepresentation createExternalId(GId sourceId, String type, String identifier) {
+        final ManagedObjectRepresentation source = new ManagedObjectRepresentation();
+        source.setId(sourceId);
+
+        final ExternalIDRepresentation externalId = new ExternalIDRepresentation();
+        externalId.setManagedObject(source);
+        externalId.setExternalId(identifier);
+        externalId.setType(type);
+        return identityApi.create(externalId);
+    }
+
+    public com.google.common.base.Optional<GId> findGId(String type, String identifier) {
+        try {
+            final ExternalIDRepresentation externalId = identityApi.getExternalId(new ID(type, identifier));
+            return com.google.common.base.Optional.of(externalId.getManagedObject().getId());
+        } catch (final SDKException ex) {
+            if (ex.getHttpStatus() != 404) {
+                throw ex;
+            }
+        }
+        return com.google.common.base.Optional.absent();
+    }
+
+    public GId createManagedObject(String type, String name) {
+        final ManagedObjectRepresentation managedObject = new ManagedObjectRepresentation();
+        managedObject.setType(type);
+        managedObject.setName(name);
+        return inventoryApi.create(managedObject).getId();
+    }
+
+    public GId createAlarm(GId sourceId, String severity, String type, String text) {
+        final ManagedObjectRepresentation source = new ManagedObjectRepresentation();
+        source.setId(sourceId);
+
+        final AlarmRepresentation alarm = new AlarmRepresentation();
+        alarm.setSource(source);
+        alarm.setSeverity(severity);
+        alarm.setType(type);
+        alarm.setText(text);
+        alarm.setDateTime(DateTime.now());
+        alarm.setStatus(ACTIVE.name());
+
+        return alarmApi.create(alarm).getId();
+    }
+
+    public void clearAlarm(GId source, String type) {
+        final Iterable<AlarmRepresentation> alarmMaybe = findAlarm(source, type, ACTIVE, ACKNOWLEDGED);
+        for (final AlarmRepresentation alarm : alarmMaybe) {
+            alarm.setStatus(CLEARED.name());
+            alarmApi.update(alarm);
+        }
+    }
+
+    public Iterable<AlarmRepresentation> findAlarm(GId source, String type, CumulocityAlarmStatuses... alarmStatuses) {
+        try {
+            final AlarmFilter filter = new AlarmFilter().bySource(source).byType(type);
+            if (alarmStatuses != null && alarmStatuses.length > 0) {
+                filter.byStatus(alarmStatuses);
+            }
+            final AlarmCollection alarms = alarmApi.getAlarmsByFilter(filter);
+            return alarms.get().allPages();
+        } catch (final SDKException ex) {
+            if (ex.getHttpStatus() != 404) {
+                throw ex;
+            }
+        }
+        return FluentIterable.of();
+    }
+}

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
@@ -29,10 +29,23 @@ class LnsConnectionTest {
     }
 
     @Test
+    void doValidateLnsConnection_invalid_name_null() {
+        LnsConnection invalid_connection = SampleConnection.builder()
+                .name(null)
+                .description(null)
+                .user("USER NAME")
+                .password("**********")
+                .build();
+
+        InputDataValidationException inputDataValidationException = Assert.assertThrows(InputDataValidationException.class, invalid_connection::isValid);
+        assertEquals("SampleConnection is missing mandatory fields: 'name'", inputDataValidationException.getMessage());
+    }
+
+    @Test
     void doValidateLnsConnection_invalid_name_blank() {
         LnsConnection invalid_connection = SampleConnection.builder()
                                             .name("   ")
-                                            .description("")
+                                            .description(null)
                                             .user("USER NAME")
                                             .password("**********")
                                             .build();

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
@@ -29,23 +29,10 @@ class LnsConnectionTest {
     }
 
     @Test
-    void doValidateLnsConnection_invalid_name_null() {
-        LnsConnection invalid_connection = SampleConnection.builder()
-                                            .name(null)
-                                            .description(null)
-                                            .user("USER NAME")
-                                            .password("**********")
-                                            .build();
-
-        InputDataValidationException inputDataValidationException = Assert.assertThrows(InputDataValidationException.class, invalid_connection::isValid);
-        assertEquals("SampleConnection is missing mandatory fields: 'name'", inputDataValidationException.getMessage());
-    }
-
-    @Test
     void doValidateLnsConnection_invalid_name_blank() {
         LnsConnection invalid_connection = SampleConnection.builder()
                                             .name("   ")
-                                            .description(null)
+                                            .description("")
                                             .user("USER NAME")
                                             .password("**********")
                                             .build();

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/platform/repository/LpwanRepositoryTest.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/platform/repository/LpwanRepositoryTest.java
@@ -1,0 +1,126 @@
+package com.cumulocity.lpwan.platform.repository;
+
+import com.cumulocity.model.ID;
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.alarm.AlarmRepresentation;
+import com.cumulocity.rest.representation.identity.ExternalIDRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjects;
+import com.cumulocity.sdk.client.SDKException;
+import com.cumulocity.sdk.client.alarm.AlarmApi;
+import com.cumulocity.sdk.client.alarm.AlarmCollection;
+import com.cumulocity.sdk.client.alarm.AlarmFilter;
+import com.cumulocity.sdk.client.alarm.PagedAlarmCollectionRepresentation;
+import com.cumulocity.sdk.client.identity.IdentityApi;
+import com.cumulocity.sdk.client.inventory.InventoryApi;
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+
+import static com.cumulocity.model.event.CumulocityAlarmStatuses.ACTIVE;
+import static com.cumulocity.model.event.CumulocityAlarmStatuses.CLEARED;
+import static com.cumulocity.model.idtype.GId.asGId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class LpwanRepositoryTest {
+
+    @Mock
+    private IdentityApi identity;
+
+    @Mock
+    private InventoryApi inventory;
+
+    @Mock
+    private AlarmApi alarmApi;
+
+    @InjectMocks
+    private LpwanRepository lpwanRepository;
+
+    @Test
+    public void shouldTestCreateExternalId(){
+        lpwanRepository.createExternalId(GId.asGId("12345"),"DummyType", "DummyIdentifier");
+        ArgumentCaptor<ExternalIDRepresentation> externalIDRepresentationArgumentCaptor = ArgumentCaptor.forClass(ExternalIDRepresentation.class);
+        verify(identity).create(externalIDRepresentationArgumentCaptor.capture());
+        ExternalIDRepresentation externalIDRepresentation = externalIDRepresentationArgumentCaptor.getValue();
+        assertEquals(GId.asGId("12345"), externalIDRepresentation.getManagedObject().getId());
+        assertEquals("DummyIdentifier", externalIDRepresentation.getExternalId());
+        assertEquals("DummyType", externalIDRepresentation.getType());
+    }
+
+    @Test
+    public void shouldTestFindGId(){
+        ExternalIDRepresentation externalId = new ExternalIDRepresentation();
+        externalId.setManagedObject(ManagedObjects.asManagedObject(GId.asGId("12345")));
+        when(identity.getExternalId(any(ID.class))).thenReturn(externalId);
+        Optional<GId> gIdOptional = lpwanRepository.findGId("DummyType", "DummyId");
+        assertTrue(gIdOptional.isPresent());
+        assertEquals(GId.asGId("12345"), gIdOptional.get());
+    }
+
+    @Test
+    public void shouldThrowExceptionFindGId(){
+        when(identity.getExternalId(any(ID.class))).thenThrow(new SDKException(HttpStatus.NOT_FOUND.value(), "NOT FOUND"));
+        Optional<GId> gIdOptional = lpwanRepository.findGId("DummyType", "DummyId");
+        assertFalse(gIdOptional.isPresent());
+    }
+
+    @Test
+    public void shouldCreate() {
+        GId sourceId = GId.asGId(456);
+        when(alarmApi.create(any(AlarmRepresentation.class))).thenReturn(mock(AlarmRepresentation.class));
+
+        lpwanRepository.createAlarm(sourceId, "CRITICAL", "type", "text");
+
+        ArgumentCaptor<AlarmRepresentation> alarmRepresentationCaptor = ArgumentCaptor.forClass(AlarmRepresentation.class);
+        verify(alarmApi).create(alarmRepresentationCaptor.capture());
+        AlarmRepresentation actualAlarm = alarmRepresentationCaptor.getValue();
+        AlarmRepresentation expectedAlarm = representation(sourceId, "CRITICAL", "type", "text", ACTIVE.name());
+
+        assertEquals(expectedAlarm.getSource().getId(), actualAlarm.getSource().getId());
+    }
+
+    private AlarmRepresentation representation(GId sourceId, String critical, String type, String text, String status) {
+        final ManagedObjectRepresentation source = new ManagedObjectRepresentation();
+        source.setId(sourceId);
+
+        final AlarmRepresentation alarm = new AlarmRepresentation();
+        alarm.setSource(source);
+        alarm.setSeverity(critical);
+        alarm.setType(type);
+        alarm.setText(text);
+        alarm.setDateTime(new DateTime(456546));
+        alarm.setStatus(status);
+        return alarm;
+    }
+
+    @Test
+    public void shouldCLearAlarms() {
+        GId sourceId = GId.asGId(456);
+        String type = "c8y_TestType";
+
+        PagedAlarmCollectionRepresentation alarmRepresentations = mock(PagedAlarmCollectionRepresentation.class);
+        AlarmCollection alarmCollection = mock(AlarmCollection.class);
+
+        when(alarmApi.getAlarmsByFilter(any(AlarmFilter.class))).thenReturn(alarmCollection);
+        AlarmRepresentation alarmRepresentation = representation(sourceId, "CRITICAL", type, "text", CLEARED.name());
+        Iterable<AlarmRepresentation> iterable = Arrays.asList(alarmRepresentation);
+        when(alarmCollection.get()).thenReturn(alarmRepresentations);
+        when(alarmRepresentations.allPages()).thenReturn(iterable);
+
+        lpwanRepository.clearAlarm(sourceId, type);
+
+        verify(alarmApi).getAlarmsByFilter(any(AlarmFilter.class));
+        verify(alarmApi).update(alarmRepresentation);
+    }
+}

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/smaple/connection/model/SampleConnection.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/smaple/connection/model/SampleConnection.java
@@ -97,4 +97,11 @@ public class SampleConnection extends LnsConnection {
             this.setPassword(sampleConnectionWithNewData.getPassword());
         }
     }
+
+    @Override
+    public boolean checkConnectionStatus() {
+        SampleConnection sampleConnectionWithNewData = new SampleConnection();
+        sampleConnectionWithNewData.setConnectionReachable(true);
+        return true;
+    }
 }

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.108.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.111.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.100.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.104.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.102.0</revision>
-        <changelist></changelist>
+        <revision>1014.103.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.99.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.103.0</revision>
-        <changelist></changelist>
+        <revision>1014.104.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.98.0</revision>
-        <changelist></changelist>
+        <revision>1014.99.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.102.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.108.0</revision>
-        <changelist></changelist>
+        <revision>1014.109.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.109.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.110.0</revision>
-        <changelist></changelist>
+        <revision>1014.111.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.113.0</revision>
-        <changelist></changelist>
+        <revision>1014.114.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -19,11 +19,10 @@
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
-        <spring-boot-dependencies.version>2.5.12</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.5.14</spring-boot-dependencies.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
-        <jackson.version>2.12.5</jackson.version>
 
         <nexus.url>http://localhost:8080</nexus.url>
         <nexus.basePath>/nexus/content/repositories</nexus.basePath>
@@ -47,14 +46,6 @@
 
     <dependencyManagement>
         <dependencies>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
 
             <!-- jetty -->
             <!-- must be defined before spring-boot-dependencies -->

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.106.0</revision>
-        <changelist></changelist>
+        <revision>1014.107.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.101.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.101.0</revision>
-        <changelist></changelist>
+        <revision>1014.102.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.107.0</revision>
-        <changelist></changelist>
+        <revision>1014.108.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.106.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.113.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.99.0</revision>
-        <changelist></changelist>
+        <revision>1014.100.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.111.0</revision>
-        <changelist></changelist>
+        <revision>1014.112.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.112.0</revision>
-        <changelist></changelist>
+        <revision>1014.113.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.103.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.109.0</revision>
-        <changelist></changelist>
+        <revision>1014.110.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.105.0</revision>
-        <changelist></changelist>
+        <revision>1014.106.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.105.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.110.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.98.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.112.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <revision>1014.107.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.100.0</revision>
-        <changelist></changelist>
+        <revision>1014.101.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -11,8 +11,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1014.104.0</revision>
-        <changelist></changelist>
+        <revision>1014.105.0</revision>
+        <changelist>-SNAPSHOT</changelist>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/microservice/subscription/src/main/java/com/cumulocity/microservice/subscription/repository/impl/CurrentMicroserviceRepository.java
+++ b/microservice/subscription/src/main/java/com/cumulocity/microservice/subscription/repository/impl/CurrentMicroserviceRepository.java
@@ -72,6 +72,8 @@ public class CurrentMicroserviceRepository implements MicroserviceRepository {
         try {
             return rest().get(url, APPLICATION_USER_COLLECTION_MEDIA_TYPE, ApplicationUserCollectionRepresentation.class);
         } catch (final Exception ex) {
+            RestOperations rest = rest();
+
             return (ApplicationUserCollectionRepresentation) handleException("GET", url, ex);
         }
     }
@@ -90,6 +92,7 @@ public class CurrentMicroserviceRepository implements MicroserviceRepository {
             final SDKException sdkException = (SDKException) ex;
             if (sdkException.getHttpStatus() == SC_FORBIDDEN || sdkException.getHttpStatus() == SC_UNAUTHORIZED) {
                 log.warn("User has no permission to api " + method + " " + url);
+
                 log.debug("Details :", ex);
                 return null;
             } else if (sdkException.getHttpStatus() == SC_NOT_FOUND) {

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.105.0</revision>
-        <changelist></changelist>
+        <revision>1014.106.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.111.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.109.0</revision>
-        <changelist></changelist>
+        <revision>1014.110.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.104.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.113.0</revision>
-        <changelist></changelist>
+        <revision>1014.114.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.105.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.98.0</revision>
-        <changelist></changelist>
+        <revision>1014.99.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.101.0</revision>
-        <changelist></changelist>
+        <revision>1014.102.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.98.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.99.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.108.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.103.0</revision>
-        <changelist></changelist>
+        <revision>1014.104.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.112.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.102.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.100.0</revision>
-        <changelist></changelist>
+        <revision>1014.101.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.113.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.107.0</revision>
-        <changelist></changelist>
+        <revision>1014.108.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.102.0</revision>
-        <changelist></changelist>
+        <revision>1014.103.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.110.0</revision>
-        <changelist></changelist>
+        <revision>1014.111.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.108.0</revision>
-        <changelist></changelist>
+        <revision>1014.109.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.103.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.106.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.100.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.106.0</revision>
-        <changelist></changelist>
+        <revision>1014.107.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.104.0</revision>
-        <changelist></changelist>
+        <revision>1014.105.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.112.0</revision>
-        <changelist></changelist>
+        <revision>1014.113.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.101.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.109.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.107.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.111.0</revision>
-        <changelist></changelist>
+        <revision>1014.112.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     </modules>
 
     <properties>
-        <revision>1014.99.0</revision>
-        <changelist></changelist>
+        <revision>1014.100.0</revision>
+        <changelist>-SNAPSHOT</changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <revision>1014.110.0</revision>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist></changelist>
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>


### PR DESCRIPTION
Analyzing SDK-Exception in multi tenant microservices like smartrule miss additional information. when an Exception is thrown.

The timestamp is often not sufficient in cases when other microservices (smartrule <--> apama) are involved.
Analyzing the corresponding blocker with only timestamps and without tenant id was time consuming.