### PR TITLE
[MTM-45251] Extend Exception with tenant, user, responseHeader

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/PlatformImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/PlatformImpl.java
@@ -312,7 +312,7 @@ public class PlatformImpl extends PlatformParameters implements Platform {
 
     @Override
     public RestConnector rest() {
-        return new RestConnector(this, new ResponseParser(this.getResponseMapper()));
+        return new RestConnector(this, new ResponseParser(this.getResponseMapper(), this));
     }
 
 }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/PlatformParameters.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/PlatformParameters.java
@@ -124,7 +124,7 @@ public class PlatformParameters implements AutoCloseable {
         if (restConnector == null) {
             synchronized (lock) {
                 if (restConnector == null) {
-                    restConnector = new RestConnector(this, new ResponseParser(responseMapper));
+                    restConnector = new RestConnector(this, new ResponseParser(responseMapper, this));
                 }
             }
         }

--- a/java-client/src/test/java/com/cumulocity/sdk/client/ResponseParserTest.java
+++ b/java-client/src/test/java/com/cumulocity/sdk/client/ResponseParserTest.java
@@ -19,29 +19,27 @@
  */
 package com.cumulocity.sdk.client;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.when;
-
-import java.net.URI;
-
-import javax.ws.rs.core.MediaType;
-
-import javax.ws.rs.core.Response;
-
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.BaseResourceRepresentation;
+import com.cumulocity.rest.representation.ErrorMessageRepresentation;
+import com.cumulocity.rest.representation.inventory.InventoryRepresentation;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.cumulocity.model.idtype.GId;
-import com.cumulocity.rest.representation.BaseResourceRepresentation;
-import com.cumulocity.rest.representation.ErrorMessageRepresentation;
-import com.cumulocity.rest.representation.inventory.InventoryRepresentation;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.when;
 
 public class ResponseParserTest {
 
@@ -105,6 +103,31 @@ public class ResponseParserTest {
         // Then
         Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
                 .hasMessage("Http status code: " + ERROR_STATUS + "\n" + errorRepresentation);
+    }
+
+    @Test
+    public void shouldIncludeSpecificResponseHeaderInExceptionWhenStatusIsNotAsExpected() {
+        // Given
+        when(response.getStatus()).thenReturn(ERROR_STATUS);
+        ErrorMessageRepresentation errorRepresentation = new ErrorMessageRepresentation();
+        when(response.hasEntity()).thenReturn(true);
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add("Content-Type", "application/json");
+        headers.add("Location", "en.wikipedia.org:8080");
+        headers.add("x-authorization", "1bdc5db0-dfc8-43f2-9159-3827bfe48ea7.1587315996051");
+        when(response.getStringHeaders()).thenReturn(headers);
+        when(response.readEntity(ErrorMessageRepresentation.class)).thenReturn(errorRepresentation);
+
+        // When
+        Throwable thrown = catchThrowable(() -> parser.parse(response, BaseResourceRepresentation.class, EXPECTED_STATUS));
+
+        // Then
+        Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
+                .hasMessageContaining("Location: [en.wikipedia.org:8080]");
+        Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
+                .hasMessageNotContaining("Content-Type: [application/json]");
+        Assertions.assertThat(thrown).isInstanceOf(SDKException.class)
+                .hasMessageNotContaining("x-authorization");
     }
 
     @Test


### PR DESCRIPTION
Analyzing SDK-Exception in multi tenant microservices like smartrule miss additional information. when an Exception is thrown.

The timestamp is often not sufficient in cases when other microservices (smartrule <--> apama) are involved.
Analyzing the corresponding blocker with only timestamps and without tenant id was time consuming.