### PR TITLE
Feature/mtm 38260/volatilesubs

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImpl.java
@@ -78,8 +78,8 @@ public class TokenApiImpl implements TokenApi {
                 parsedToken.getSubscriber(),
                 subscription,
                 validityPeriodMinutes,
-                parsedToken.getShared(),
-                parsedToken.getNonPersistent()));
+                parsedToken.isShared(),
+                parsedToken.isNonPersistent()));
     }
 
     @Override

--- a/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImpl.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImpl.java
@@ -77,7 +77,9 @@ public class TokenApiImpl implements TokenApi {
         return create(new NotificationTokenRequestRepresentation(
                 parsedToken.getSubscriber(),
                 subscription,
-                validityPeriodMinutes, false));
+                validityPeriodMinutes,
+                parsedToken.getShared(),
+                parsedToken.getNonPersistent()));
     }
 
     @Override

--- a/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenClaims.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenClaims.java
@@ -21,6 +21,10 @@ public class TokenClaims extends BaseResourceRepresentation {
 
     private long exp;
 
+    private boolean shared;
+
+    private boolean nonPersistent;
+
     @JSONProperty(value = "sub", ignoreIfNull = true)
     public String getSubscriber() {
         return this.subscriber;
@@ -44,5 +48,15 @@ public class TokenClaims extends BaseResourceRepresentation {
     @JSONProperty(ignoreIfNull = true)
     public long getExp() {
         return this.exp;
+    }
+
+    @JSONProperty(value = "shared", ignoreIfNull = false)
+    public boolean getShared() {
+        return this.shared;
+    }
+
+    @JSONProperty(value = "volatile", ignoreIfNull = false)
+    public boolean getNonPersistent() {
+        return this.nonPersistent;
     }
 }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenClaims.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenClaims.java
@@ -50,12 +50,12 @@ public class TokenClaims extends BaseResourceRepresentation {
         return this.exp;
     }
 
-    @JSONProperty(value = "shared", ignoreIfNull = false)
+    @JSONProperty(value = "shared", ignoreIfNull = true)
     public boolean getShared() {
         return this.shared;
     }
 
-    @JSONProperty(value = "volatile", ignoreIfNull = false)
+    @JSONProperty(value = "volatile", ignoreIfNull = true)
     public boolean getNonPersistent() {
         return this.nonPersistent;
     }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenClaims.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/messaging/notifications/TokenClaims.java
@@ -51,12 +51,12 @@ public class TokenClaims extends BaseResourceRepresentation {
     }
 
     @JSONProperty(value = "shared", ignoreIfNull = true)
-    public boolean getShared() {
+    public boolean isShared() {
         return this.shared;
     }
 
     @JSONProperty(value = "volatile", ignoreIfNull = true)
-    public boolean getNonPersistent() {
+    public boolean isNonPersistent() {
         return this.nonPersistent;
     }
 }

--- a/java-client/src/test/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImplTest.java
+++ b/java-client/src/test/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImplTest.java
@@ -125,7 +125,56 @@ public class TokenApiImplTest {
         assertThat(argumentCaptor.getValue().getSubscriber()).isEqualTo("testsubscriber");
         assertThat(argumentCaptor.getValue().getSubscription()).isEqualTo("testsubscription");
         assertThat(argumentCaptor.getValue().getExpiresInMinutes()).isEqualTo(1L);
+        assertThat(argumentCaptor.getValue().isShared()).isFalse();
+        assertThat(argumentCaptor.getValue().isNonPersistent()).isFalse();
     }
+
+    @Test
+    public void shouldRefreshSharedToken() {
+        //given
+        String expiredSharedJwtToken = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3Vic2NyaWJlciIsInNoYXJlZCI6InRydWUiLCJ0" +
+                "b3BpYyI6Im1hbmFnZW1lbnQvcmVsbm90aWYvdGVzdHN1YnNjcmlwdGlvbiIsImp0aSI6IjE3MzI0YzIyLTczMjktNGJjNS05YTAz" +
+                "LWZiYTk5YmFjNzZhMSIsImlhdCI6MTY1NzcwOTY1MSwiZXhwIjoxNjU3NzA5NzExfQ.MKxWB7W-BDv_p-wb1z2nvR9Jmy9oEgTpa" +
+                "cs05IV-AkJEcinVVK4uDoi7HI8DwrqWmtFYIWhI3HEa-4-3fB4VjvPJdAsAcWcBQW5pGGNtVkRkXkKRzPO_wmrCMp8uqtv9zJpwj" +
+                "AMUWWFlnAP10WqsZvLtIX0fS-PWZmf6PAKzElZQGKOn5Gg_ycC49tbm6MuieuH1NT6LRFs4xHESDgJf9iMwEnzzZrOuo9JhUFiS1" +
+                "bdePGVPDmSRmgrdML7Ogv4wFblsq4oTnuC4VtRisXLczBJJhyf6Mqx6Anh78amLIWA1qpKfUcizUGjpllqm862EAOuPZnJDPMf-1" +
+                "1a55IcdhA";
+        ArgumentCaptor<NotificationTokenRequestRepresentation> argumentCaptor = ArgumentCaptor.forClass(NotificationTokenRequestRepresentation.class);
+
+        //when
+        tokenApi.refresh(new Token(expiredSharedJwtToken));
+
+        verify(tokenApi).create(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getSubscriber()).isEqualTo("testsubscriber");
+        assertThat(argumentCaptor.getValue().getSubscription()).isEqualTo("testsubscription");
+        assertThat(argumentCaptor.getValue().getExpiresInMinutes()).isEqualTo(1L);
+        assertThat(argumentCaptor.getValue().isShared()).isTrue();
+        assertThat(argumentCaptor.getValue().isNonPersistent()).isFalse();
+    }
+
+    @Test
+    public void shouldRefreshNonPersistentToken() {
+        //given
+        String expiredNonPersistentJwtToken = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3Vic2NyaWJlciIsInRvcGljIjoibWFuY" +
+                "WdlbWVudC9yZWxub3RpZi90ZXN0c3Vic2NyaXB0aW9uIiwidm9sYXRpbGUiOiJ0cnVlIiwianRpIjoiZDIzNjE3MDEtYmRlYi00M" +
+                "TIzLWI4YjItYTliYTFkYjZjNzkyIiwiaWF0IjoxNjU3NzA5NDU0LCJleHAiOjE2NTc3MDk1MTR9.Ny12cVUlZXD4YSm_ZZFI0M29" +
+                "5ne_NcQrXFGpVvYrtuB670TLFbgNyM2ep9ItuevECzqI0Ur7WY5kk2HnfTMe3lUi6ojP78J3xX4VH1Ar-NFK0U5aW91nvWg7C31F" +
+                "pj9OnXmESjMn-RjeP-FDZxzZdAveIgOXlyigS8xkLLXLcoxXi3L50z_6UvwpBKqnaS5DLveCgpNYGA4VzbX-74dZj2MnVMKfPc9p" +
+                "qUICB_lDiR3z68_X1v9EkSOsc2jYHAWH6GcAApRmRx6geaxwIsbq-QFEBJ1mAkAYG9PeXIe_XFFrBvwLEg6W3F8Gu7YHDfpDakIl" +
+                "qRVgckoi-nUChJX3Mw";
+        ArgumentCaptor<NotificationTokenRequestRepresentation> argumentCaptor = ArgumentCaptor.forClass(NotificationTokenRequestRepresentation.class);
+
+        //when
+        tokenApi.refresh(new Token(expiredNonPersistentJwtToken));
+
+        verify(tokenApi).create(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getSubscriber()).isEqualTo("testsubscriber");
+        assertThat(argumentCaptor.getValue().getSubscription()).isEqualTo("testsubscription");
+        assertThat(argumentCaptor.getValue().getExpiresInMinutes()).isEqualTo(1L);
+        assertThat(argumentCaptor.getValue().isShared()).isFalse();
+        assertThat(argumentCaptor.getValue().isNonPersistent()).isTrue();
+    }
+
 
     private String getUri(String endpoint) {
         return HOST + endpoint;

--- a/java-client/src/test/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImplTest.java
+++ b/java-client/src/test/java/com/cumulocity/sdk/client/messaging/notifications/TokenApiImplTest.java
@@ -40,7 +40,7 @@ public class TokenApiImplTest {
     public void shouldCreateToken() {
         //given
         NotificationTokenRequestRepresentation tokenRequest =
-                new NotificationTokenRequestRepresentation("sub", "sup", 1L, false);
+                new NotificationTokenRequestRepresentation("sub", "sup", 1L, false, false);
         Token token = new Token(JWT_TOKEN);
 
         //when
@@ -59,7 +59,7 @@ public class TokenApiImplTest {
     public void shouldBuildCreateTokenUri() {
         //given
         NotificationTokenRequestRepresentation tokenRequest =
-                new NotificationTokenRequestRepresentation("sub", "sup", 1L, false);
+                new NotificationTokenRequestRepresentation("sub", "sup", 1L, false, false);
         final String uri = getUri(TokenApiImpl.TOKEN_REQUEST_URI);
         when(restConnector.post(any(), any(), any(), any(), any())).thenReturn(new Token());
 
@@ -78,7 +78,7 @@ public class TokenApiImplTest {
     @Test
     public void shouldVerifyToken() {
         //given
-        TokenClaims tokenRequest = new TokenClaims("sub", "topic", "jti", 1L, 1L);
+        TokenClaims tokenRequest = new TokenClaims("sub", "topic", "jti", 1L, 1L, false, false);
         final String uri = getUri(TokenApiImpl.TOKEN_REQUEST_URI + "?token=" + JWT_TOKEN);
         Token tokenToVerify = new Token(JWT_TOKEN);
 


### PR DESCRIPTION
This is a rename (locally a rename for me but a copy here on origin for now) of MTM-38260-refresh-shared-non-persistent-tokens

This is as the new fields in core classes have changed the constructor contracts causing the contracts expected by the develop clients to no longer exist. Clients-java is built in pre-merge pipeline causing a chicken & egg issue. See https://jenkins.dev.c8y.io/blue/organizations/jenkins/cumulocity-core-pre-merge/detail/PR-210/18/pipeline/140.

Advice was to create a branch with same name in core and clients so the sympathetic changes in clients in this branch will be used in the core pre-merge.

Ownership of branch has changed and approvals needed again