### PR TITLE
MTM-46090 set upstream to core build on SNAPSHOT post-merge

### DIFF
--- a/.jenkins/github/Jenkinsfile
+++ b/.jenkins/github/Jenkinsfile
@@ -11,6 +11,10 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '10'))
         timeout(time: 20, unit: 'MINUTES')
     }
+    triggers {
+        upstream(upstreamProjects: "/${currentBuild.fullProjectName.replaceFirst('cumulocity-clients-java', 'cumulocity-core')}",
+            threshold: hudson.model.Result.SUCCESS)
+    }
     environment {
         MVN_SETTINGS = credentials('maven-settings')
     }


### PR DESCRIPTION
It will cause `cumulocity-clients-java` build to trigger, for a matching branch, after the upstream `cumulociy-core` succeeds.