### PR TITLE
DM-1265 Restrict certain special characters during creation of LNS Connection

### DIFF
--- a/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
+++ b/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
@@ -85,7 +85,7 @@ public abstract class LnsConnection {
         }
 
         if(!name.matches(VALID_CONNECTION)) {
-            throw new InputDataValidationException(this.getClass().getSimpleName() + " has special characters that are not allowed. These are %, ;, /, &, \", ', \\, *");
+            throw new InputDataValidationException(this.getClass().getSimpleName() + " has restricted special characters %, ;, /, &, \", ', \\, *");
         }
 
         this.validate();

--- a/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
+++ b/lpwan-backend/src/main/java/com/cumulocity/lpwan/lns/connection/model/LnsConnection.java
@@ -32,6 +32,8 @@ import java.util.*;
 @NoArgsConstructor
 public abstract class LnsConnection {
 
+    private static final String VALID_CONNECTION = "^[^\\%\\;\\/\\&\\\"\\'\\\\\\*]*$";
+
     @NotBlank
     @JsonView(LnsConnection.PublicView.class)
     private String name;
@@ -80,6 +82,10 @@ public abstract class LnsConnection {
 
         if (!missingFields.isEmpty()) {
             throw new InputDataValidationException(this.getClass().getSimpleName() + " is missing mandatory fields: " + String.join(", ", missingFields));
+        }
+
+        if(!name.matches(VALID_CONNECTION)) {
+            throw new InputDataValidationException(this.getClass().getSimpleName() + " has special characters that are not allowed. These are %, ;, /, &, \", ', \\, *");
         }
 
         this.validate();

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
@@ -70,7 +70,7 @@ class LnsConnectionTest {
                 .build();
 
         InputDataValidationException inputDataValidationException = Assert.assertThrows(InputDataValidationException.class, invalid_connection::isValid);
-        assertEquals("SampleConnection has special characters that are not allowed. These are %, ;, /, &, \", ', \\, *", inputDataValidationException.getMessage());
+        assertEquals("SampleConnection has restricted special characters %, ;, /, &, \", ', \\, *", inputDataValidationException.getMessage());
 
         LnsConnection invalid_connection_2 = SampleConnection.builder()
                 .name("a!#c&d~^(76*5$) '")
@@ -80,7 +80,7 @@ class LnsConnectionTest {
                 .build();
 
         InputDataValidationException inputDataValidationException_2 = Assert.assertThrows(InputDataValidationException.class, invalid_connection_2::isValid);
-        assertEquals("SampleConnection has special characters that are not allowed. These are %, ;, /, &, \", ', \\, *", inputDataValidationException_2.getMessage());
+        assertEquals("SampleConnection has restricted special characters %, ;, /, &, \", ', \\, *", inputDataValidationException_2.getMessage());
     }
 
     @Test

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/lns/connection/model/LnsConnectionTest.java
@@ -29,6 +29,12 @@ class LnsConnectionTest {
     }
 
     @Test
+    void doValidateLnsConnection_valid_name_special_characters() throws InputDataValidationException {
+        assertTrue(VALID_SAMPLE_CONNECTION_SPECIAL_CHARACTERS_1.isValid());
+        assertTrue(VALID_SAMPLE_CONNECTION_SPECIAL_CHARACTERS_2.isValid());
+    }
+
+    @Test
     void doValidateLnsConnection_invalid_name_null() {
         LnsConnection invalid_connection = SampleConnection.builder()
                 .name(null)
@@ -55,6 +61,29 @@ class LnsConnectionTest {
     }
 
     @Test
+    void doValidateLnsConnection_invalid_name_special_characters() {
+        LnsConnection invalid_connection = SampleConnection.builder()
+                .name("null null !@#$%^*::&'\"")
+                .description(null)
+                .user("USER NAME")
+                .password("**********")
+                .build();
+
+        InputDataValidationException inputDataValidationException = Assert.assertThrows(InputDataValidationException.class, invalid_connection::isValid);
+        assertEquals("SampleConnection has special characters that are not allowed. These are %, ;, /, &, \", ', \\, *", inputDataValidationException.getMessage());
+
+        LnsConnection invalid_connection_2 = SampleConnection.builder()
+                .name("a!#c&d~^(76*5$) '")
+                .description(null)
+                .user("USER NAME")
+                .password("**********")
+                .build();
+
+        InputDataValidationException inputDataValidationException_2 = Assert.assertThrows(InputDataValidationException.class, invalid_connection_2::isValid);
+        assertEquals("SampleConnection has special characters that are not allowed. These are %, ;, /, &, \", ', \\, *", inputDataValidationException_2.getMessage());
+    }
+
+    @Test
     void doValidateLnsConnection_invalid_user_null() {
         LnsConnection invalid_connection = SampleConnection.builder()
                                                 .name("Sample Connection Name")
@@ -68,7 +97,7 @@ class LnsConnectionTest {
     }
 
     @Test
-    void doValidateLnsConnection_invalid_user_balnk() {
+    void doValidateLnsConnection_invalid_user_blank() {
         LnsConnection invalid_connection = SampleConnection.builder()
                                             .name("Sample Connection Name")
                                             .description("Sample Connection Description")

--- a/lpwan-backend/src/test/java/com/cumulocity/lpwan/sample/connection/model/SampleConnection.java
+++ b/lpwan-backend/src/test/java/com/cumulocity/lpwan/sample/connection/model/SampleConnection.java
@@ -47,6 +47,20 @@ public class SampleConnection extends LnsConnection {
                                                                             .password("**********")
                                                                             .build();
 
+    public static final SampleConnection VALID_SAMPLE_CONNECTION_SPECIAL_CHARACTERS_1 = SampleConnection.builder()
+            .name("a!#cd~^ (76 5$)")
+            .description("Sample Connection Description")
+            .user("USER NAME")
+            .password("**********")
+            .build();
+
+    public static final SampleConnection VALID_SAMPLE_CONNECTION_SPECIAL_CHARACTERS_2 = SampleConnection.builder()
+            .name("(null null !@#$^::~`),.")
+            .description("Sample Connection Description")
+            .user("USER NAME")
+            .password("**********")
+            .build();
+
     // Use the below commented code to generate the Json for INTERNAL VIEW (which includes "password" field)
     // System.out.println(new ObjectMapper().writerWithView(LnsConnection.InternalView.class).writeValueAsString(VALID_SAMPLE_CONNECTION));
     //    {


### PR DESCRIPTION
Restrict special characters %, ;, /, \, &, ', ", *

These cause issues during deletion of LNS Connection like RequestRejectionException from Spring, bad request etc. 