### PR TITLE
MTM-50684 fixes lombok-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <junit.version>5.8.2</junit.version>
         <logback.version>1.2.11</logback.version>
         <lombok.version>1.18.24</lombok.version>
-        <lombok-plugin.version>${lombok.version}.0</lombok-plugin.version>
+        <lombok-plugin.version>1.18.20.0</lombok-plugin.version>
         <microemu.version>2.0.4</microemu.version>
         <mockito.version>3.12.4</mockito.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
While [`org.projectlombok:lombok:1.18.24`](https://mvnrepository.com/artifact/org.projectlombok/lombok) exists, the most recent version of the Maven plugin actually is [`org.projectlombok:lombok-maven-plugin:1.18.20.0`](https://mvnrepository.com/artifact/org.projectlombok/lombok-maven-plugin).