### PR TITLE
MTM-28681: add x-forwarded-host header to client request

### DIFF
--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/token/CumulocityCoreAuthenticationClient.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/token/CumulocityCoreAuthenticationClient.java
@@ -42,7 +42,6 @@ class CumulocityCoreAuthenticationClient {
         }
     }
 
-
     /**
      * Remember to release resources when client is not needed
      */
@@ -124,12 +123,14 @@ class CumulocityCoreAuthenticationClient {
     @Provider
     private static class ForwardedHeaderOnRequestFilter implements ClientRequestFilter {
 
-        private final static String TENANT_ID = "Tenant-ID";
+        // this header added by proxy contains domain of origin client. It is forwarded
+        // to cumulocity in microservice request
+        private final static String X_Forwarded_Host = "X-Forwarded-Host";
 
         private final HttpServletRequest request;
         @Override
         public void filter(ClientRequestContext clientRequestContext) throws IOException {
-            clientRequestContext.getHeaders().add(TENANT_ID, request.getHeader(TENANT_ID));
+            clientRequestContext.getHeaders().add(X_Forwarded_Host, request.getHeader(X_Forwarded_Host));
         }
     }
 

--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/token/CumulocityOAuthMicroserviceFilter.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/token/CumulocityOAuthMicroserviceFilter.java
@@ -66,6 +66,8 @@ public class CumulocityOAuthMicroserviceFilter extends GenericFilterBean {
                 final boolean debug = logger.isDebugEnabled();
                 try {
                     JwtTokenAuthentication jwtTokenAuthentication = new JwtTokenAuthentication(jwtCredentials.get());
+                    // we build the core client with additional information from the request
+                    CumulocityCoreAuthenticationClient.setRequest(request);
                     Authentication authResult = authenticationManager.authenticate(jwtTokenAuthentication);
                     if (debug) {
                         logger.debug("Authentication success: " + authResult);

--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/token/CumulocityOAuthMicroserviceFilter.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/token/CumulocityOAuthMicroserviceFilter.java
@@ -66,8 +66,7 @@ public class CumulocityOAuthMicroserviceFilter extends GenericFilterBean {
                 final boolean debug = logger.isDebugEnabled();
                 try {
                     JwtTokenAuthentication jwtTokenAuthentication = new JwtTokenAuthentication(jwtCredentials.get());
-                    // we build the core client with additional information from the request
-                    CumulocityCoreAuthenticationClient.setRequest(request);
+
                     Authentication authResult = authenticationManager.authenticate(jwtTokenAuthentication);
                     if (debug) {
                         logger.debug("Authentication success: " + authResult);

--- a/microservice/security/src/main/java/com/cumulocity/microservice/security/token/JwtTokenAuthenticationProvider.java
+++ b/microservice/security/src/main/java/com/cumulocity/microservice/security/token/JwtTokenAuthenticationProvider.java
@@ -2,6 +2,7 @@ package com.cumulocity.microservice.security.token;
 
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
@@ -10,12 +11,17 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.SpringSecurityMessageSource;
 
+import javax.servlet.http.HttpServletRequest;
+
 @Slf4j
 public class JwtTokenAuthenticationProvider implements AuthenticationProvider, MessageSourceAware {
 
     protected MessageSourceAccessor messages;
     private final Environment environment;
     private final JwtAuthenticatedTokenCache tokenCache;
+    @Autowired
+    private HttpServletRequest request;
+
 
     public JwtTokenAuthenticationProvider(Environment environment, JwtAuthenticatedTokenCache tokenCache) {
         this.environment = environment;
@@ -37,7 +43,7 @@ public class JwtTokenAuthenticationProvider implements AuthenticationProvider, M
                 @Override
                 public JwtTokenAuthentication call() {
                     String baseUrl = environment.getProperty("C8Y.baseURL");
-                    return CumulocityCoreAuthenticationClient.authenticateUserAndUpdateToken(baseUrl, jwtTokenAuthentication);
+                    return CumulocityCoreAuthenticationClient.authenticateUserAndUpdateToken(baseUrl, jwtTokenAuthentication, request);
                 }
             });
         } catch (ExecutionException e) {


### PR DESCRIPTION
When a tenant calls a micro-service (ms), the ms-proxy ads the **x-forwarded-host** to the request before forwarding to the ms (see https://github.softwareag.com/IOTA/cumulocity-core/pull/1390).

The client sdk then forwards it back the core. This is done to facilitate tenant resolution when micro-services makes request to core. Currently tenants are resolved either using their public domain or id. And as microservice calls are not performed using
the domain, this allows to resolve the tenant and proceed with authentication. 

This is in the scope of https://cumulocity.atlassian.net/browse/MTM-32644  