### PR TITLE
Updated Maven to version 3.9.1

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip


### PR DESCRIPTION
Due to https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291 requires HTTPS to be used for mirrors.

Blocked by https://cumulocity.atlassian.net/browse/MTM-52418