### PR TITLE
MTM-53340 Updates org.json:json due to CVE-2022-45688

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20190722</version>
+			<version>20230227</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
MTM-53340 Updates org.json:json due to CVE-2022-45688

Dependency only used in single method:
 - `com.cumulocity.sdk.client.notification.MessageExchange.ResponseConsumer#retryHandleContent()`