### PR TITLE
MTM-53341 Updates com.jayway.jsonpath:json-path due to CVE-2022-45688

### DIFF
--- a/java-client-model/pom.xml
+++ b/java-client-model/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>1.2.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>


### PR DESCRIPTION
MTM-53341 Updates com.jayway.jsonpath:json-path due to CVE-2022-45688
MTM-53343 Transitively updates net.minidev:json-smart due to CVE-2023-1370