### PR TITLE
MTM-53342 Updates Spring Boot due to vulnerable transitive dependencies

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -19,7 +19,7 @@
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
-        <spring-boot-dependencies.version>2.7.6</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.11</spring-boot-dependencies.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>


### PR DESCRIPTION
MTM-53342 Updates org.springframework:spring-core due to CVE-2023-20860 
MTM-53346 Updates org.springframework:spring-web due to CVE-2023-20860 
MTM-53344 Updates org.springframework.security:spring-security-crypto due to CVE-2023-20862 
MTM-53345 Updates org.springframework.security:spring-security-core due to CVE-2023-20862 
MTM-53347 Updates org.springframework.security:spring-security-web due to CVE-2023-20862 
MTM-53339 Updates com.fasterxml.jackson.core:jackson-core due to CVE-2022-45688

Causes https://github.softwareag.com/IOTA/cumulocity-agents/pull/1014