### PR TITLE
MTM-53359 Updates org.eclipse.jetty:jetty-* due to CVE-2022-2048

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -20,7 +20,7 @@
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
         <spring-boot-dependencies.version>2.7.6</spring-boot-dependencies.version>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
         <rest-assured.version>4.5.1</rest-assured.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jaxrs.version>2.1.6</jaxrs.version>
-        <jetty.version>9.4.45.v20220203</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <junit.version>5.8.2</junit.version>
         <logback.version>1.2.11</logback.version>


### PR DESCRIPTION
MTM-53359 Updates org.eclipse.jetty:jetty-* due to CVE-2022-2048

`org.eclipse.jetty:jetty-util` is a transitive dependency of `org.cometd.java:cometd-java-client`