### PR TITLE
MTM-53340 Removes org.json:json due to CVE-2022-45688

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -92,11 +92,6 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20190722</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/MessageExchange.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/MessageExchange.java
@@ -25,14 +25,14 @@ import org.cometd.client.transport.TransportListener;
 import org.cometd.common.TransportException;
 import javax.ws.rs.core.Response;
 
-import org.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.svenson.JSON;
+import org.svenson.JSONParser;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.InvocationCallback;
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
@@ -271,11 +271,11 @@ class MessageExchange {
          * continue when single message parsing fail
          */
         private boolean retryHandleContent(String content) {
-            JSONArray jsonArray = new JSONArray(content);
-            List<Mutable> messages = new ArrayList<>(jsonArray.length());
+            List<?> jsonArray = JSONParser.defaultJSONParser().parse(List.class, content);
+            List<Mutable> messages = new ArrayList<>(jsonArray.size());
             for (Object jsonObject : jsonArray) {
                 try {
-                    messages.addAll(transport.parseMessages(jsonObject.toString()));
+                    messages.addAll(transport.parseMessages(JSON.defaultJSON().forValue(jsonObject)));
                 } catch(ParseException | IllegalArgumentException e) {
                     log.debug("Failed to retry parse json message: {}", e.getMessage());
                 }

--- a/lpwan-backend/pom.xml
+++ b/lpwan-backend/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>commons-csv</artifactId>
             <version>1.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
MTM-53340 Removes org.json:json due to CVE-2022-45688

Alternative to https://github.com/SoftwareAG/cumulocity-clients-java/pull/329

Causes:
 - https://github.softwareag.com/IOTA/cumulocity-agents/pull/994
 - https://github.softwareag.com/IOTA/cumulocity-quality/pull/1895