### PR TITLE
MTM-53341 Removes com.jayway.jsonpath:json-path due to CVE-2022-45688

### DIFF
--- a/java-client-model/pom.xml
+++ b/java-client-model/pom.xml
@@ -35,11 +35,6 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <version>1.2.0</version>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>

--- a/java-client-model/src/main/java/com/cumulocity/model/authentication/Jsons.java
+++ b/java-client-model/src/main/java/com/cumulocity/model/authentication/Jsons.java
@@ -1,11 +1,12 @@
 package com.cumulocity.model.authentication;
 
 import com.google.common.base.Optional;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.PathNotFoundException;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.svenson.JSONParser;
+
+import java.util.Map;
 
 @Slf4j
 @UtilityClass
@@ -14,7 +15,7 @@ public class Jsons {
     public static Optional<String> readField(String field, String json) {
         try {
             return readValueAsString(field, json);
-        } catch (PathNotFoundException e) {
+        } catch (Exception e) {
             return Optional.absent();
         }
     }
@@ -23,7 +24,7 @@ public class Jsons {
         if (StringUtils.isEmpty(field)) {
             return Optional.absent();
         }
-        Object value = JsonPath.read(json, "$." + field);
-        return value == null ? Optional.absent() : Optional.of(value.toString());
+        Map<?, ?> data = JSONParser.defaultJSONParser().parse(Map.class, json);
+        return Optional.fromNullable(data.get(field)).transform(String::valueOf);
     }
 }


### PR DESCRIPTION
MTM-53341 Removes com.jayway.jsonpath:json-path due to CVE-2022-45688
MTM-53343 Transitively removes net.minidev:json-smart due to CVE-2023-1370

Alternative to https://github.com/SoftwareAG/cumulocity-clients-java/pull/330

Causes https://github.softwareag.com/IOTA/cumulocity-agents/pull/995