### PR TITLE
MTM-53432 MQTT Connect Specify Subscriber Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 Cumulocity Clients Java
 ---------------
 

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/MqttConfig.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/MqttConfig.java
@@ -14,4 +14,5 @@ public interface MqttConfig {
 
     String getTopic();
 
+    String getSubscriber();
 }

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketClientBuilder.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketClientBuilder.java
@@ -3,6 +3,7 @@ package com.cumulocity.mqtt.connect.client.websocket;
 import com.cumulocity.mqtt.connect.client.*;
 import com.cumulocity.mqtt.connect.client.model.MqttMessage;
 import com.cumulocity.sdk.client.messaging.notifications.TokenApi;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.MalformedURLException;
 
@@ -63,6 +64,9 @@ public class MqttWebSocketClientBuilder {
 
             @Override
             public MqttSubscriber buildSubscriber(final MqttConfig config) {
+                if (StringUtils.isBlank(config.getSubscriber())) {
+                    throw new MqttClientException("Subscriber has to be provided");
+                }
                 return new MqttWebSocketSubscriber(url, tokenApi, (MqttWebSocketConfig) config);
             }
 

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketClientBuilder.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketClientBuilder.java
@@ -64,9 +64,7 @@ public class MqttWebSocketClientBuilder {
 
             @Override
             public MqttSubscriber buildSubscriber(final MqttConfig config) {
-                if (StringUtils.isBlank(config.getSubscriber())) {
-                    throw new MqttClientException("Subscriber has to be provided");
-                }
+                validateSubscriber(config.getSubscriber());
                 return new MqttWebSocketSubscriber(url, tokenApi, (MqttWebSocketConfig) config);
             }
 
@@ -82,6 +80,12 @@ public class MqttWebSocketClientBuilder {
 
         if (!(url.startsWith("ws://") || url.startsWith("wss://"))) {
             throw new MqttClientException("Server URI should specify either 'ws://' or 'wss://' protocol", new MalformedURLException());
+        }
+    }
+
+    private void validateSubscriber(String subscriber) {
+        if (StringUtils.isBlank(subscriber)) {
+            throw new MqttClientException("Subscriber has to be provided");
         }
     }
 

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketConfig.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketConfig.java
@@ -18,6 +18,12 @@ public class MqttWebSocketConfig implements MqttConfig {
     private final String topic;
 
     /**
+     * Specify the subscriber (consumer) name which will be used by the instance of {@link MqttPublisher} or {@link MqttSubscriber}.
+     * It is mandatory for instance of {@link MqttSubscriber}.
+     */
+    private final String subscriber;
+
+    /**
      * Connection timeout in millis second until the websocket connected or failed to do so.
      */
     @Builder.Default

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketConfig.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketConfig.java
@@ -18,8 +18,7 @@ public class MqttWebSocketConfig implements MqttConfig {
     private final String topic;
 
     /**
-     * Specify the subscriber (consumer) name which will be used by the instance of {@link MqttPublisher} or {@link MqttSubscriber}.
-     * It is mandatory for instance of {@link MqttSubscriber}.
+     * Specify the subscriber name (consumer name) which will be used by the instance of {@link MqttSubscriber}.
      */
     private final String subscriber;
 

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketPublisher.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketPublisher.java
@@ -10,9 +10,12 @@ import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 class MqttWebSocketPublisher implements MqttPublisher {
 
-    private final static String SUBSCRIBER = "mqttConnectPublisher";
+    private final static String SUBSCRIBER_PREFIX = "mqttConnectPublisher";
     private final static String WEBSOCKET_URL_PATTERN = "%s/notification2/producer/?token=%s";
     private final String webSocketBaseUrl;
 
@@ -25,7 +28,7 @@ class MqttWebSocketPublisher implements MqttPublisher {
     MqttWebSocketPublisher(String webSocketBaseUrl, TokenApi tokenApi, MqttWebSocketConfig config) {
         this.webSocketBaseUrl = webSocketBaseUrl;
         this.config = config;
-        this.tokenSupplier = new TokenSupplier(tokenApi, config.getTopic(), SUBSCRIBER);
+        this.tokenSupplier = new TokenSupplier(tokenApi, config.getTopic(), getSubscriber());
     }
 
     @Override
@@ -55,5 +58,13 @@ class MqttWebSocketPublisher implements MqttPublisher {
         if (producer != null) {
             producer.close();
         }
+    }
+
+    private String getSubscriber() {
+        if (isBlank(config.getSubscriber())) {
+            return SUBSCRIBER_PREFIX + randomAlphabetic(10);
+        }
+
+        return config.getSubscriber();
     }
 }

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketPublisher.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketPublisher.java
@@ -10,11 +10,9 @@ import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-
 class MqttWebSocketPublisher implements MqttPublisher {
 
-    private final static String SUBSCRIBER_PREFIX = "mqttConnectPublisher";
+    private final static String SUBSCRIBER = "mqttConnectPublisher";
     private final static String WEBSOCKET_URL_PATTERN = "%s/notification2/producer/?token=%s";
     private final String webSocketBaseUrl;
 
@@ -27,7 +25,7 @@ class MqttWebSocketPublisher implements MqttPublisher {
     MqttWebSocketPublisher(String webSocketBaseUrl, TokenApi tokenApi, MqttWebSocketConfig config) {
         this.webSocketBaseUrl = webSocketBaseUrl;
         this.config = config;
-        this.tokenSupplier = new TokenSupplier(tokenApi, config.getTopic(), getSubscriber());
+        this.tokenSupplier = new TokenSupplier(tokenApi, config.getTopic(), SUBSCRIBER);
     }
 
     @Override
@@ -57,9 +55,5 @@ class MqttWebSocketPublisher implements MqttPublisher {
         if (producer != null) {
             producer.close();
         }
-    }
-
-    private String getSubscriber() {
-        return SUBSCRIBER_PREFIX + randomAlphabetic(10);
     }
 }

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketPublisher.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketPublisher.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 class MqttWebSocketPublisher implements MqttPublisher {
 
@@ -61,10 +60,6 @@ class MqttWebSocketPublisher implements MqttPublisher {
     }
 
     private String getSubscriber() {
-        if (isBlank(config.getSubscriber())) {
-            return SUBSCRIBER_PREFIX + randomAlphabetic(10);
-        }
-
-        return config.getSubscriber();
+        return SUBSCRIBER_PREFIX + randomAlphabetic(10);
     }
 }

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketSubscriber.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/MqttWebSocketSubscriber.java
@@ -22,7 +22,7 @@ class MqttWebSocketSubscriber implements MqttSubscriber {
     MqttWebSocketSubscriber(String webSocketBaseUrl, TokenApi tokenApi, MqttWebSocketConfig config) {
         this.webSocketBaseUrl = webSocketBaseUrl;
         this.config = config;
-        this.tokenSupplier = new TokenSupplier(tokenApi, config.getTopic(), SUBSCRIBER);
+        this.tokenSupplier = new TokenSupplier(tokenApi, config.getTopic(), config.getSubscriber());
     }
 
     @Override

--- a/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/TokenSupplier.java
+++ b/mqtt-connect/websocket/src/main/java/com/cumulocity/mqtt/connect/client/websocket/TokenSupplier.java
@@ -7,8 +7,6 @@ import com.google.common.base.Suppliers;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-
 class TokenSupplier {
 
     private static long TOKEN_EXPIRATION_IN_MINUTES = 1440;
@@ -39,7 +37,7 @@ class TokenSupplier {
 
     private NotificationTokenRequestRepresentation getTokenRepresentation() {
         final NotificationTokenRequestRepresentation representation = new NotificationTokenRequestRepresentation();
-        representation.setSubscriber(subscriber + randomAlphabetic(10));
+        representation.setSubscriber(subscriber);
         representation.setSubscription(topic);
         representation.setType(TOKEN_TYPE);
         representation.setSigned(true);


### PR DESCRIPTION
Removed auto-generated random subscriber/consumer name from MqttSubscriber.  It now requires you to specify the subscriber name instead and therefore reducing the chances of random untracked consumers causing havoc on the messaging service. 