### PR TITLE
MTM-54196 fix realtime longpolling re-subscribe issues when dealing with "402::Unknown client" errors

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/ConnectionHeartBeatWatcher.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/ConnectionHeartBeatWatcher.java
@@ -59,7 +59,6 @@ class ConnectionHeartBeatWatcher {
                 } else {
                     onConnectionActive();
                 }
-
             }
 
             private void onConnectionActive() {

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/CumulocityLongPollingTransport.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/CumulocityLongPollingTransport.java
@@ -25,12 +25,10 @@ import org.cometd.bayeux.Message.Mutable;
 import org.cometd.client.transport.HttpClientTransport;
 import org.cometd.client.transport.TransportListener;
 import org.glassfish.jersey.client.ClientProperties;
-import javax.ws.rs.core.Response;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.core.NewCookie;
 import java.net.CookieStore;
 import java.net.HttpCookie;
 import java.text.ParseException;
@@ -107,7 +105,7 @@ class CumulocityLongPollingTransport extends HttpClientTransport {
 
     @Override
     public void send(final TransportListener listener, List<Mutable> messages) {
-        logger.debug("sending messages {} ", (Object) messages);
+        logger.debug("sending messages {} ", messages);
         final String content = generateJSON(messages);
         try {
             synchronized (exchanges) {
@@ -143,7 +141,6 @@ class CumulocityLongPollingTransport extends HttpClientTransport {
                     exchanges.remove(exchange);
                 }
             }
-
         });
         exchanges.add(exchange);
     }
@@ -152,25 +149,6 @@ class CumulocityLongPollingTransport extends HttpClientTransport {
         final long heartbeat = Long.getLong(CumulocityLongPollingTransport.class.getName()+ ".long-poll.heartbeat-interval", TimeUnit.MINUTES.toSeconds(12));
         logger.debug("Long poll heartbeat interval resolved to {} seconds", heartbeat);
         return heartbeat;
-    }
-
-    private Response copyCookies(final Response clientResponse) {
-        CookieStore cookieStore = getCookieStore();
-        for (NewCookie cookie : clientResponse.getCookies().values()) {
-            cookieStore.add(null, toHttpCookie(cookie));
-        }
-        return clientResponse;
-    }
-
-    private HttpCookie toHttpCookie(NewCookie newCookie) {
-        HttpCookie httpCookie = new HttpCookie(newCookie.getName(), newCookie.getValue());
-        httpCookie.setDomain(newCookie.getDomain());
-        httpCookie.setPath(newCookie.getPath());
-        httpCookie.setVersion(newCookie.getVersion());
-        httpCookie.setSecure(newCookie.isSecure());
-        httpCookie.setMaxAge(newCookie.getMaxAge());
-        httpCookie.setComment(newCookie.getComment());
-        return httpCookie;
     }
 
     @Override

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/MessageExchange.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/MessageExchange.java
@@ -23,8 +23,6 @@ import lombok.Synchronized;
 import org.cometd.bayeux.Message.Mutable;
 import org.cometd.client.transport.TransportListener;
 import org.cometd.common.TransportException;
-import javax.ws.rs.core.Response;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.svenson.JSON;
@@ -33,6 +31,7 @@ import org.svenson.JSONParser;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;


### PR DESCRIPTION
The solution for subscription failing with "402::Unknown client" (and resulting lack of notifications) was already provided with MTM-39963 but it still suffered from race conditions when trying to re-subscribe on failure:
* sometimes there were still old subscribers in channel
* session was not always in CONNECTED state

With this fix:
* realtime client tries to resubscribe on "402::Unknown client" failure only when in CONNECTED state, otherwise subscription is stored in pendingSubscriptions
* each successful /meta/connect goes through pending subscriptions
* new periodic job verifying bayeux channels for subscriptions have subscribers