### PR TITLE
MTM-55422 * fix a regression causing duplicate subscriptions

### DIFF
--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeAlarmNotificationIT.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeAlarmNotificationIT.java
@@ -10,6 +10,7 @@ import com.cumulocity.sdk.client.common.TestSubscriptionListener;
 import com.cumulocity.sdk.client.inventory.InventoryApi;
 import com.cumulocity.sdk.client.notification.wrappers.RealtimeAlarmMessage;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -22,17 +23,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.TEN_SECONDS;
 
-public class RealtimeAlarmNotificationClientIT extends JavaSdkITBase {
+public class RealtimeAlarmNotificationIT extends JavaSdkITBase {
     private static final String ALARMS = "/alarms/";
     private static final String ALARMS_WITH_CHILDREN = "/alarmsWithChildren/";
 
     final InventoryApi inventoryApi = platform.getInventoryApi();
     final AlarmApi alarmApi = platform.getAlarmApi();
 
+    Subscriber<String, RealtimeAlarmMessage> subscriber;
+
+    @AfterEach
+    public void cleanUp() {
+        if (subscriber != null) {
+            subscriber.disconnect();
+        }
+    }
+
     @Test
-    public void shouldReceiveCreateAlarmNotification() throws Exception {
+    public void shouldReceiveCreateAlarmNotification() {
         // given
-        Subscriber<String, RealtimeAlarmMessage> subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
+        subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
         ManagedObjectRepresentation mo = inventoryApi.create(aSampleMo().build());
         TestSubscriptionListener<RealtimeAlarmMessage> subscriptionListener = new TestSubscriptionListener<>();
 
@@ -51,9 +61,9 @@ public class RealtimeAlarmNotificationClientIT extends JavaSdkITBase {
     // https://cumulocity.atlassian.net/browse/MTM-38784
     @Disabled
     @Test
-    public void shouldReceiveUpdateAlarmNotification() throws Exception {
+    public void shouldReceiveUpdateAlarmNotification() {
         // given
-        Subscriber<String, RealtimeAlarmMessage> subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
+        subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
         ManagedObjectRepresentation mo = inventoryApi.create(aSampleMo().build());
         AlarmRepresentation alarm = alarmApi.create(createAlarmRep(mo));
         TestSubscriptionListener<RealtimeAlarmMessage> subscriptionListener = new TestSubscriptionListener<>();
@@ -70,9 +80,9 @@ public class RealtimeAlarmNotificationClientIT extends JavaSdkITBase {
     }
 
     @Test
-    public void shouldReceiveCreateChildAlarmNotification() throws Exception {
+    public void shouldReceiveCreateChildAlarmNotification() {
         // given
-        Subscriber<String, RealtimeAlarmMessage> subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
+        subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
         ManagedObjectRepresentation parentMO = inventoryApi.create(aSampleMo().build());
         ManagedObjectRepresentation childMo = aSampleChildMo(parentMO.getId());
         TestSubscriptionListener<RealtimeAlarmMessage> subscriptionListener = new TestSubscriptionListener<>();
@@ -92,9 +102,9 @@ public class RealtimeAlarmNotificationClientIT extends JavaSdkITBase {
     // https://cumulocity.atlassian.net/browse/MTM-38784
     @Disabled
     @Test
-    public void shouldReceiveUpdateChildAlarmNotification() throws Exception {
+    public void shouldReceiveUpdateChildAlarmNotification() {
         // given
-        Subscriber<String, RealtimeAlarmMessage> subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
+        subscriber = getSubscriberForType(RealtimeAlarmMessage.class, platform);
         ManagedObjectRepresentation parentMO = inventoryApi.create(aSampleMo().build());
         ManagedObjectRepresentation childMo = aSampleChildMo(parentMO.getId());
         AlarmRepresentation alarm = alarmApi.create(createAlarmRep(childMo));

--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeMultiSubNotificationIT.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeMultiSubNotificationIT.java
@@ -1,0 +1,194 @@
+package com.cumulocity.sdk.client.notification;
+
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.AbstractExtensibleRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.rest.representation.operation.OperationRepresentation;
+import com.cumulocity.sdk.client.common.JavaSdkITBase;
+import com.cumulocity.sdk.client.devicecontrol.DeviceControlApi;
+import com.cumulocity.sdk.client.inventory.InventoryApi;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.cumulocity.sdk.client.notification.SubscriberBuilder.REALTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_SECOND;
+import static org.awaitility.Durations.TEN_SECONDS;
+
+@Slf4j
+public class RealtimeMultiSubNotificationIT extends JavaSdkITBase {
+    private static final int CONCURRENT_JOBS = 10;
+
+    InventoryApi inventoryApi = platform.getInventoryApi();
+    DeviceControlApi operationsApi = platform.getDeviceControlApi();
+
+    @Test
+    public void shouldNotReceiveDuplicatedOperations() throws InterruptedException, ExecutionException {
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_JOBS);
+
+        List<Callable<Boolean>> jobs = new ArrayList<>();
+        for (int jobNo = 0; jobNo < CONCURRENT_JOBS; ++jobNo) {
+            jobs.add(new SubscriberJob(jobNo));
+        }
+
+        boolean failed = false;
+        for (Future<Boolean> result : executor.invokeAll(jobs)) {
+            if (!result.get()) {
+                failed = true;
+                break;
+            }
+        }
+
+        assertThat(failed)
+                .withFailMessage("Test failed. See the logs to investigate the issue.")
+                .isFalse();
+    }
+
+    private class SubscriberJob implements Callable<Boolean> {
+        private final int jobNo;
+        private final Subscriber<String, RealtimeMessage> subscriber;
+
+        public SubscriberJob(int jobNo) {
+            this.jobNo = jobNo;
+            this.subscriber = SubscriberBuilder.<String, RealtimeMessage>anSubscriber()
+                    .withParameters(platform)
+                    .withEndpoint(REALTIME)
+                    .withSubscriptionNameResolver(name -> name)
+                    .withDataType(RealtimeMessage.class)
+                    .build();
+        }
+
+        @Override
+        public Boolean call() throws InterruptedException {
+            ManagedObjectRepresentation device = inventoryApi.create(aMoDevice());
+
+            AtomicInteger opCounter = new AtomicInteger(0);
+            List<Subscription<String>> subscriptions = subscribe(device.getId(), opCounter);
+
+            operationsApi.create(aDeviceOperation(device.getId()));
+
+            try {
+                // check counter as fast as possible and then wait 1s to verify it didn't go up
+                await().atMost(TEN_SECONDS).until(() -> opCounter.get() == 1);
+                await().pollDelay(ONE_SECOND).atMost(TEN_SECONDS).until(() -> opCounter.get() == 1);
+            } catch (ConditionTimeoutException ex) {
+                log.error("Subscription test failed with notifications count {} (should be 1)", opCounter.get());
+                return false;
+            }
+
+            subscriptions.forEach(Subscription::unsubscribe);
+            subscriber.disconnect();
+
+            return opCounter.get() == 1;
+        }
+
+        private List<Subscription<String>> subscribe(GId deviceId, AtomicInteger opCounter) throws InterruptedException {
+            CountDownLatch subOpLatch = new CountDownLatch(5);
+
+            List<Subscription<String>> subscriptions = Stream.of("measurements", "alarms", "events", "managedobjects")
+                    .map(channel -> subscriber.subscribe(
+                            "/" + channel + "/*",
+                            new CountDownLatchSubscriptionOperationListener(jobNo, subOpLatch),
+                            new CountingSubscriptionListener(jobNo, opCounter, deviceId),
+                            true))
+                    .collect(Collectors.toList());
+
+            subscriptions.add(subscriber.subscribe(
+                    "/operations/*",
+                    new CountDownLatchSubscriptionOperationListener(jobNo, subOpLatch),
+                    new CountingSubscriptionListener(jobNo, opCounter, deviceId),
+                    true));
+
+
+            assertThat(subOpLatch.await(10, TimeUnit.SECONDS))
+                    .withFailMessage("There are %d not successful subscriptions left)", subOpLatch.getCount())
+                    .isTrue();
+
+            return subscriptions;
+        }
+
+        private ManagedObjectRepresentation aMoDevice() {
+            ManagedObjectRepresentation mo;
+            mo = new ManagedObjectRepresentation();
+            mo.setName("Test Device " + jobNo);
+            mo.setType("NotificationsDevice");
+            mo.setProperty("c8y_IsDevice", new HashMap<>());
+            mo.setProperty("com_cumulocity_model_Agent", new HashMap<>());
+            return mo;
+        }
+
+        private OperationRepresentation aDeviceOperation(GId deviceId) {
+            OperationRepresentation operation = new OperationRepresentation();
+            operation.setDeviceId(deviceId);
+            operation.setProperty("Restart", new HashMap<>());
+            return operation;
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class CountingSubscriptionListener implements SubscriptionListener<String, RealtimeMessage> {
+        private final int jobNo;
+        private final AtomicInteger notificationCount;
+        private final GId deviceId;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void onNotification(Subscription<String> subscription, RealtimeMessage notification) {
+            log.info("SubscriberJob-{}: Received job for {}, notification.realtimeAction={}, notification.data={}",
+                    jobNo, subscription.getObject(), notification.getRealtimeAction(), notification.getData());
+            if (subscription.getObject().equals("/operations/*")) {
+                Object data = notification.getData();
+                if (data instanceof Map) {
+                    String notificationDeviceId = (String) ((Map<String, Object>) data).get("deviceId");
+                    if (deviceId.getValue().equals(notificationDeviceId)) {
+                        log.info("SubscriberJob-{}: Received operation notification for deviceId = {}", jobNo, deviceId.getValue());
+                        notificationCount.incrementAndGet();
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onError(Subscription<String> subscription, Throwable ex) {
+            log.error("SubscriberJob-{}: Received error for {}", jobNo, subscription.getObject(), ex);
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class CountDownLatchSubscriptionOperationListener implements SubscribeOperationListener {
+        private final int jobNo;
+        private final CountDownLatch subscriptionLatch;
+
+        @Override
+        public void onSubscribingSuccess(String channelId) {
+            subscriptionLatch.countDown();
+            log.info("SubscriberJob-{}: Successfully subscribed: {}", jobNo, channelId);
+        }
+
+        @Override
+        public void onSubscribingError(String channelId, String message, Throwable throwable) {
+            log.warn("SubscriberJob-{}: Error when subscribing channel: {}, error: {}", jobNo, channelId, message, throwable);
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class RealtimeMessage extends AbstractExtensibleRepresentation {
+        private Object data;
+        private String realtimeAction;
+    }
+}

--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeNotificationMockServerIT.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeNotificationMockServerIT.java
@@ -5,9 +5,7 @@ import com.cumulocity.sdk.client.PlatformImpl;
 import com.cumulocity.sdk.client.common.SystemPropertiesOverrider;
 import com.cumulocity.sdk.client.inventory.InventoryIT;
 import com.google.gson.Gson;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
 import org.mockserver.mock.action.ExpectationCallback;
@@ -26,12 +24,14 @@ import static org.mockserver.model.HttpClassCallback.callback;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class RealtimeNotificationConnectionMockServerIT {
+public class RealtimeNotificationMockServerIT {
 
     private static ClientAndServer mockServer;
     private static Properties cumulocityProps;
     private static SystemPropertiesOverrider props;
     private static Gson gson;
+
+    private Subscriber<String, AlarmRepresentation> subscriber;
 
     @BeforeAll
     public static void createTenantWithApplication() throws IOException {
@@ -47,14 +47,23 @@ public class RealtimeNotificationConnectionMockServerIT {
         mockServer.stop();
     }
 
+    @BeforeEach
+    public void setUp() throws IOException {
+        subscriber = givenAlarmSubscriber();
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        subscriber.disconnect();
+    }
+
     @Test
     public void shouldResubscribeWhen402UnknownClientError() throws IOException {
 
         //given
-        givenMockWithCallbackResponse(1,".*/meta/handshake.*", MetaHandshakeSuccessfulResponseCallback.class);
-        givenMockWithCallbackResponse(1,".*/meta/connect.*", MetaConnectSuccessfulResponseCallback.class);
-        givenMockWithCallbackResponse(2, ".*/meta/subscribe.*", MetaSubscribeErrorResponseCallback.class );
-        Subscriber<String, AlarmRepresentation> subscriber = givenAlarmSubscriber();
+        givenMockWithCallbackResponse(1, ".*/meta/handshake.*", MetaHandshakeSuccessfulResponseCallback.class);
+        givenMockWithCallbackResponse(1, ".*/meta/connect.*", MetaConnectSuccessfulResponseCallback.class);
+        givenMockWithCallbackResponse(2, ".*/meta/subscribe.*", MetaSubscribeErrorResponseCallback.class);
 
         //when
         subscribe(subscriber);
@@ -68,19 +77,17 @@ public class RealtimeNotificationConnectionMockServerIT {
         mockServer.verify(request()
                 .withPath("/notification/realtime")
                 .withBody(new RegexBody(".*/meta/subscribe.*")), VerificationTimes.atLeast(2));
-
     }
 
     @Test
     public void shouldReHandshakeWhen402UnknownClientError() throws IOException {
 
         //given
-        givenMockWithCallbackResponse(1,".*/meta/handshake.*", MetaHandshakeErrorResponseCallback.class);
-        givenMockWithCallbackResponse(2,".*/meta/handshake.*", MetaHandshakeSuccessfulResponseCallback.class);
-        givenMockWithCallbackResponse(1,".*/meta/connect.*", MetaConnectErrorResponseCallback.class);
-        givenMockWithCallbackResponse(2,".*/meta/connect.*", MetaConnectSuccessfulResponseCallback.class);
-        givenMockWithCallbackResponse(2, ".*/meta/subscribe.*", MetaSubscribeErrorResponseCallback.class );
-        Subscriber<String, AlarmRepresentation> subscriber = givenAlarmSubscriber();
+        givenMockWithCallbackResponse(1, ".*/meta/handshake.*", MetaHandshakeErrorResponseCallback.class);
+        givenMockWithCallbackResponse(2, ".*/meta/handshake.*", MetaHandshakeSuccessfulResponseCallback.class);
+        givenMockWithCallbackResponse(1, ".*/meta/connect.*", MetaConnectErrorResponseCallback.class);
+        givenMockWithCallbackResponse(2, ".*/meta/connect.*", MetaConnectSuccessfulResponseCallback.class);
+        givenMockWithCallbackResponse(2, ".*/meta/subscribe.*", MetaSubscribeErrorResponseCallback.class);
 
         //when
         subscribe(subscriber);
@@ -98,7 +105,6 @@ public class RealtimeNotificationConnectionMockServerIT {
         mockServer.verify(request()
                 .withPath("/notification/realtime")
                 .withBody(new RegexBody(".*/meta/subscribe.*")), VerificationTimes.atLeast(2));
-
     }
 
     private void subscribe(Subscriber<String, AlarmRepresentation> subscriber) {
@@ -123,68 +129,68 @@ public class RealtimeNotificationConnectionMockServerIT {
 
     private Subscriber<String, AlarmRepresentation> givenAlarmSubscriber() throws IOException {
         return SubscriberBuilder.<String, AlarmRepresentation>anSubscriber()
-                    .withParameters(new PlatformImpl(props.get("mock.server.host")+":"+ props.get("mock.server.port"), from(props.get("mock.server.credentials"))))
-                    .withEndpoint(SubscriberBuilder.REALTIME)
-                    .withSubscriptionNameResolver(id -> id)
-                    .withDataType(AlarmRepresentation.class)
-                    .build();
+                .withParameters(new PlatformImpl(props.get("mock.server.host") + ":" + props.get("mock.server.port"), from(props.get("mock.server.credentials"))))
+                .withEndpoint(SubscriberBuilder.REALTIME)
+                .withSubscriptionNameResolver(id -> id)
+                .withDataType(AlarmRepresentation.class)
+                .build();
     }
 
     private static void givenMockWithCallbackResponse(int repeatTimes, String requestBodyRegex, Class<? extends ExpectationCallback<? extends HttpMessage>> responseCallback) {
         mockServer.when(request()
-                .withHeader(Header.header("Content-Type", "application/json"))
-                .withBody(new RegexBody(requestBodyRegex))
-                .withPath("/notification/realtime"), Times.exactly(repeatTimes))
+                        .withHeader(Header.header("Content-Type", "application/json"))
+                        .withBody(new RegexBody(requestBodyRegex))
+                        .withPath("/notification/realtime"), Times.exactly(repeatTimes))
                 .respond(callback().withCallbackClass(responseCallback));
     }
 
     public static class MetaSubscribeErrorResponseCallback implements ExpectationResponseCallback {
         @Override
         public HttpResponse handle(HttpRequest httpRequest) {
-            String jsonBody= httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() -1);
+            String jsonBody = httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() - 1);
             Map map = gson.fromJson(jsonBody, Map.class);
             String requestId = (String) map.get("id");
-            return response("[{\"channel\":\"/meta/subscribe\",\"id\":\""+requestId+"\",\"subscription\":\"/alarms/*\",\"error\":\"402::Unknown client\",\"data\":null,\"successful\":false}]");
+            return response("[{\"channel\":\"/meta/subscribe\",\"id\":\"" + requestId + "\",\"subscription\":\"/alarms/*\",\"error\":\"402::Unknown client\",\"data\":null,\"successful\":false}]");
         }
     }
 
     public static class MetaConnectErrorResponseCallback implements ExpectationResponseCallback {
         @Override
         public HttpResponse handle(HttpRequest httpRequest) {
-            String jsonBody= httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() -1);
+            String jsonBody = httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() - 1);
             Map map = gson.fromJson(jsonBody, Map.class);
             String requestId = (String) map.get("id");
-            return response("[{\"channel\":\"/meta/connect\",\"id\":\""+requestId+"\",\"error\":\"402::Unknown client\",\"data\":null,\"advice\":{\"interval\":0,\"reconnect\":\"handshake\"},\"successful\":false}]");
+            return response("[{\"channel\":\"/meta/connect\",\"id\":\"" + requestId + "\",\"error\":\"402::Unknown client\",\"data\":null,\"advice\":{\"interval\":0,\"reconnect\":\"handshake\"},\"successful\":false}]");
         }
     }
 
     public static class MetaConnectSuccessfulResponseCallback implements ExpectationResponseCallback {
         @Override
         public HttpResponse handle(HttpRequest httpRequest) {
-            String jsonBody= httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() -1);
+            String jsonBody = httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() - 1);
             Map map = gson.fromJson(jsonBody, Map.class);
             String requestId = (String) map.get("id");
-            return response("[{\"channel\":\"/meta/connect\",\"id\":\""+requestId+"\",\"data\":null,\"advice\":{\"interval\":0,\"timeout\":5400000,\"reconnect\":\"retry\"},\"successful\":true}]");
+            return response("[{\"channel\":\"/meta/connect\",\"id\":\"" + requestId + "\",\"data\":null,\"advice\":{\"interval\":0,\"timeout\":5400000,\"reconnect\":\"retry\"},\"successful\":true}]");
         }
     }
 
     public static class MetaHandshakeSuccessfulResponseCallback implements ExpectationResponseCallback {
         @Override
         public HttpResponse handle(HttpRequest httpRequest) {
-            String jsonBody= httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() -1);
+            String jsonBody = httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() - 1);
             Map map = gson.fromJson(jsonBody, Map.class);
             String requestId = (String) map.get("id");
-            return response("[{\"ext\":{\"ack\":true},\"minimumVersion\":\"1.0\",\"clientId\":\"2s1128n70miv86f189yoto03tp9a\",\"supportedConnectionTypes\":[\"long-polling\",\"smartrest-long-polling\",\"websocket\"],\"data\":null,\"channel\":\"/meta/handshake\",\"id\":\""+requestId+"\",\"version\":\"1.0\",\"successful\":true}]");
+            return response("[{\"ext\":{\"ack\":true},\"minimumVersion\":\"1.0\",\"clientId\":\"2s1128n70miv86f189yoto03tp9a\",\"supportedConnectionTypes\":[\"long-polling\",\"smartrest-long-polling\",\"websocket\"],\"data\":null,\"channel\":\"/meta/handshake\",\"id\":\"" + requestId + "\",\"version\":\"1.0\",\"successful\":true}]");
         }
     }
 
     public static class MetaHandshakeErrorResponseCallback implements ExpectationResponseCallback {
         @Override
         public HttpResponse handle(HttpRequest httpRequest) {
-            String jsonBody= httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() -1);
+            String jsonBody = httpRequest.getBodyAsString().substring(1, httpRequest.getBodyAsString().length() - 1);
             Map map = gson.fromJson(jsonBody, Map.class);
             String requestId = (String) map.get("id");
-            return response("[{\"ext\":{\"ack\":true},\"minimumVersion\":\"1.0\",\"clientId\":\"99yvbr3zrfl3901cxv3wjeekjo9\",\"supportedConnectionTypes\":[\"long-polling\",\"smartrest-long-polling\",\"websocket\"],\"data\":null,\"channel\":\"/meta/handshake\",\"id\":\""+requestId+"\",\"version\":\"1.0\",\"successful\":true}]");
+            return response("[{\"ext\":{\"ack\":true},\"minimumVersion\":\"1.0\",\"clientId\":\"99yvbr3zrfl3901cxv3wjeekjo9\",\"supportedConnectionTypes\":[\"long-polling\",\"smartrest-long-polling\",\"websocket\"],\"data\":null,\"channel\":\"/meta/handshake\",\"id\":\"" + requestId + "\",\"version\":\"1.0\",\"successful\":true}]");
         }
     }
 }

--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeOperationNotificationIT.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/RealtimeOperationNotificationIT.java
@@ -1,0 +1,105 @@
+package com.cumulocity.sdk.client.notification;
+
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.rest.representation.operation.OperationRepresentation;
+import com.cumulocity.sdk.client.common.JavaSdkITBase;
+import com.cumulocity.sdk.client.common.TestSubscriptionListener;
+import com.cumulocity.sdk.client.devicecontrol.DeviceControlApi;
+import com.cumulocity.sdk.client.inventory.InventoryApi;
+import com.cumulocity.sdk.client.notification.wrappers.RealtimeOperationMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static com.cumulocity.sdk.client.common.Subscribers.getSubscriberForType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.TEN_SECONDS;
+
+public class RealtimeOperationNotificationIT extends JavaSdkITBase {
+    private static final String OPERATIONS = "/operations/";
+
+    private final InventoryApi inventoryApi = platform.getInventoryApi();
+    private final DeviceControlApi operationsApi = platform.getDeviceControlApi();
+
+    private Subscriber<String, RealtimeOperationMessage> subscriber;
+
+    @AfterEach
+    public void cleanUp() {
+        if (subscriber != null) {
+            subscriber.disconnect();
+        }
+    }
+
+    @Test
+    public void shouldReceiveCreateOperationNotification() {
+        // given
+        subscriber = getSubscriberForType(RealtimeOperationMessage.class, platform);
+        ManagedObjectRepresentation device = inventoryApi.create(aMoDevice());
+        TestSubscriptionListener<RealtimeOperationMessage> subscriptionListener = new TestSubscriptionListener<>();
+
+        // when
+        subscriber.subscribe(OPERATIONS + device.getId().getValue(), subscriptionListener, subscriptionListener, true);
+        await().atMost(TEN_SECONDS).until(subscriptionListener::isSubscribed);
+        OperationRepresentation operation = operationsApi.create(aDeviceOperation(device.getId()));
+
+        // then
+        await().atMost(TEN_SECONDS).until(subscriptionListener::notificationReceived);
+        assertThat(subscriptionListener.getNotification()).isExactlyInstanceOf(RealtimeOperationMessage.class);
+        assertOperationNotification(subscriptionListener.getNotification(), operation, "CREATE");
+    }
+
+    @Test
+    public void shouldReceiveUpdateOperationNotification() {
+        // given
+        subscriber = getSubscriberForType(RealtimeOperationMessage.class, platform);
+        ManagedObjectRepresentation device = inventoryApi.create(aMoDevice());
+        OperationRepresentation operation = operationsApi.create(aDeviceOperation(device.getId()));
+        TestSubscriptionListener<RealtimeOperationMessage> subscriptionListener = new TestSubscriptionListener<>();
+
+        // when
+        assertThat(operation.getStatus()).isEqualTo("PENDING");
+        subscriber.subscribe(OPERATIONS + device.getId().getValue(), subscriptionListener, subscriptionListener, true);
+        await().atMost(TEN_SECONDS).until(subscriptionListener::isSubscribed);
+        OperationRepresentation updatedOperation = operationsApi.update(aDeviceOperationUpdate(operation.getId()));
+
+        // then
+        assertThat(updatedOperation.getStatus()).isEqualTo("EXECUTING");
+        await().atMost(TEN_SECONDS).until(subscriptionListener::notificationReceived);
+        assertThat(subscriptionListener.getNotification()).isExactlyInstanceOf(RealtimeOperationMessage.class);
+        assertOperationNotification(subscriptionListener.getNotification(), updatedOperation, "UPDATE");
+    }
+
+    private ManagedObjectRepresentation aMoDevice() {
+        ManagedObjectRepresentation mo;
+        mo = new ManagedObjectRepresentation();
+        mo.setName("Test Device");
+        mo.setType("NotificationsDevice");
+        mo.setProperty("c8y_IsDevice", new HashMap<>());
+        mo.setProperty("com_cumulocity_model_Agent", new HashMap<>());
+        return mo;
+    }
+
+    private OperationRepresentation aDeviceOperation(GId deviceId) {
+        OperationRepresentation operation = new OperationRepresentation();
+        operation.setDeviceId(deviceId);
+        operation.setProperty("Restart", new HashMap<>());
+        return operation;
+    }
+
+    private OperationRepresentation aDeviceOperationUpdate(GId operationId) {
+        OperationRepresentation operation = new OperationRepresentation();
+        operation.setId(operationId);
+        operation.setStatus("EXECUTING");
+        return operation;
+    }
+
+    private void assertOperationNotification(RealtimeOperationMessage notification, OperationRepresentation source, String realtimeAction) {
+        assertThat(notification.getData().getId()).isEqualTo(source.getId());
+        assertThat(notification.getData().getStatus()).isEqualTo(source.getStatus());
+        assertThat(notification.getData().getDeviceId()).isEqualTo(source.getDeviceId());
+        assertThat(notification.getAttrs().get("realtimeAction")).isEqualTo(realtimeAction);
+    }
+}

--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/wrappers/RealtimeDeleteMessage.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/wrappers/RealtimeDeleteMessage.java
@@ -1,0 +1,11 @@
+package com.cumulocity.sdk.client.notification.wrappers;
+
+import com.cumulocity.rest.representation.AbstractExtensibleRepresentation;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RealtimeDeleteMessage extends AbstractExtensibleRepresentation {
+    String data;
+}

--- a/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/wrappers/RealtimeOperationMessage.java
+++ b/java-client/src/integration-test/java/com/cumulocity/sdk/client/notification/wrappers/RealtimeOperationMessage.java
@@ -1,11 +1,12 @@
 package com.cumulocity.sdk.client.notification.wrappers;
 
 import com.cumulocity.rest.representation.AbstractExtensibleRepresentation;
+import com.cumulocity.rest.representation.operation.OperationRepresentation;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class RealtimeDeleteRepresentationWrapper extends AbstractExtensibleRepresentation {
-    String data;
+public class RealtimeOperationMessage extends AbstractExtensibleRepresentation {
+    OperationRepresentation data;
 }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/CumulocityLongPollingTransport.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/CumulocityLongPollingTransport.java
@@ -54,7 +54,7 @@ class CumulocityLongPollingTransport extends HttpClientTransport {
 
     private final Client httpClient;
 
-    final List<MessageExchange> exchanges = new LinkedList<MessageExchange>();
+    final List<MessageExchange> exchanges = new LinkedList<>();
 
     final ScheduledExecutorService executorService = newScheduledThreadPool(WORKERS, new CumulocityLongPollingTransportThreadFactory());
 
@@ -125,7 +125,7 @@ class CumulocityLongPollingTransport extends HttpClientTransport {
 
     private void createMessageExchange(final TransportListener listener, final String content, List<Mutable> messages) {
         final ConnectionHeartBeatWatcher watcher = new ConnectionHeartBeatWatcher(executorService, resolveHeartbeatInterval());
-        httpClient.property(ClientProperties.READ_TIMEOUT, (int) TimeUnit.SECONDS.toMillis(resolveHeartbeatInterval()+30));
+        httpClient.property(ClientProperties.READ_TIMEOUT, (int) TimeUnit.SECONDS.toMillis(resolveHeartbeatInterval() + 30));
         final MessageExchange exchange = new MessageExchange(this, httpClient, executorService, listener, watcher, unauthorizedConnectionWatcher, messages);
         watcher.addConnectionListener(new ConnectionIdleListener() {
             @Override
@@ -146,7 +146,7 @@ class CumulocityLongPollingTransport extends HttpClientTransport {
     }
 
     private long resolveHeartbeatInterval() {
-        final long heartbeat = Long.getLong(CumulocityLongPollingTransport.class.getName()+ ".long-poll.heartbeat-interval", TimeUnit.MINUTES.toSeconds(12));
+        final long heartbeat = Long.getLong(CumulocityLongPollingTransport.class.getName() + ".long-poll.heartbeat-interval", TimeUnit.MINUTES.toSeconds(12));
         logger.debug("Long poll heartbeat interval resolved to {} seconds", heartbeat);
         return heartbeat;
     }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/MessageExchange.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/MessageExchange.java
@@ -101,7 +101,7 @@ class MessageExchange {
 
     @Synchronized("messages")
     public void cancel() {
-        log.debug("canceling {}",  messages);
+        log.debug("canceling {}", messages);
 
 
         if (request.cancel(true)) {
@@ -166,7 +166,7 @@ class MessageExchange {
 
         private void heartBeatWatch(Response clientResponse) throws IOException {
             if (isOk(clientResponse)) {
-                InputStream responseStream = (InputStream)clientResponse.getEntity();
+                InputStream responseStream = (InputStream) clientResponse.getEntity();
                 log.debug("getting heartbeats  {}", clientResponse);
                 getHeartBeats(responseStream);
             }
@@ -275,7 +275,7 @@ class MessageExchange {
             for (Object jsonObject : jsonArray) {
                 try {
                     messages.addAll(transport.parseMessages(JSON.defaultJSON().forValue(jsonObject)));
-                } catch(ParseException | IllegalArgumentException e) {
+                } catch (ParseException | IllegalArgumentException e) {
                     log.debug("Failed to retry parse json message: {}", e.getMessage());
                 }
             }

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/Subscriber.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/Subscriber.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 Cumulocity GmbH
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation the rights to use,
  * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
@@ -27,7 +27,8 @@ public interface Subscriber<T, R> {
     Subscription<T> subscribe(T object, SubscriptionListener<T, R> handler) throws SDKException;
 
     Subscription<T> subscribe(T object, final SubscribeOperationListener subscribeOperationListener,
-                                        final SubscriptionListener<T, R> handler,
-                                        final boolean autoRetry) throws SDKException;
+                              final SubscriptionListener<T, R> handler,
+                              final boolean autoRetry) throws SDKException;
+
     void disconnect();
 }

--- a/java-client/src/test/java/com/cumulocity/sdk/client/notification/SubscriberImplTest.java
+++ b/java-client/src/test/java/com/cumulocity/sdk/client/notification/SubscriberImplTest.java
@@ -314,7 +314,6 @@ public class SubscriberImplTest {
     }
 
     @Test
-    @Disabled // FIXME (issue with class casting)
     public void shouldNotAddSubscribeListenerWhenChannelHasSubscriber() {
         final String channelId = "/channel";
         final ClientSessionChannel channel = givenChannel(channelId);


### PR DESCRIPTION
This fixes a regression where a successful response to `/meta/connect` message caused a resubscription of pending subscriptions (the ones waiting for the response to the `/meta/subscribe` request) -- this caused unexpected number of channel subscribers. To remedy that:
* only failed subscriptions are processed as a result of `/meta/connect` message
* subscribe method is synchronized and there is a check if subscribing channel was already subscribed with the same handlers

There are also:
* new integration tests for realtime operations
* a test for this specific regression with duplicate subscriptions
* some cleanup: disconnecting subscribers in integration tests after the tests so the threads are not hanging and we don't have weird messages logged