### PR TITLE
[MTM-56165] upgrade guava to next non-vulnerable version

### DIFF
--- a/microservice/package/pom.xml
+++ b/microservice/package/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>31.1-jre</version>
+			<version>32.0.1-jre</version>
 		</dependency>
 
 		<dependency>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -21,7 +21,7 @@
 
         <spring-boot-dependencies.version>2.7.17</spring-boot-dependencies.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
-        <guava.version>31.0.1-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
         <rest-assured.version>4.5.1</rest-assured.version>
 


### PR DESCRIPTION
Try 32.0.1-jre as guava version.