### PR TITLE
Bugfix/MTM-56458/Graft_update_Spring_boot_dependencies

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -19,7 +19,7 @@
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
-        <spring-boot-dependencies.version>2.7.6</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.14</spring-boot-dependencies.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <mockito.version>4.5.1</mockito.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>${spring-framework.version}</spring.version><!-- deprecated, use spring-framework.version instead -->
-        <spring-framework.version>5.3.24</spring-framework.version>
+        <spring-framework.version>5.3.29</spring-framework.version>
         <svenson.version>1.5.8</svenson.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <commons-io.version>2.8.0</commons-io.version>


### PR DESCRIPTION
This PR is in the context of https://cumulocity.atlassian.net/browse/MTM-56458 to address 
[CVE-2023-34034](https://nvd.nist.gov/vuln/detail/CVE-2023-34034)

The spring-boot-dependencies are set to version 2.7.14 and with that the vulnerable component spring-security-config is upgraded to the non-vulnerable version 5.7.10. 

As spring security 5.7.10 requires spring framework version 5.3.29+ , the spring framework version is also updated to 5.3.29.