### PR TITLE
MTM-56458 Graft 1018 Spring boot update

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -19,7 +19,7 @@
         <cumulocity.core.version>${project.version}</cumulocity.core.version>
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
-        <spring-boot-dependencies.version>2.7.11</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.17</spring-boot-dependencies.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>


### PR DESCRIPTION
This PR is in the context of https://cumulocity.atlassian.net/browse/MTM-56458 to address
[CVE-2023-34034](https://nvd.nist.gov/vuln/detail/CVE-2023-34034) and a graft of https://github.com/SoftwareAG/cumulocity-clients-java/pull/385 to 1018.

The spring-boot-dependencies are set to version 2.7.17 and with that the vulnerable component spring-security-config is upgraded to the non-vulnerable version 5.7.11.