### PR TITLE
MTM-56693 Update jetty version in microservice SDK and java SDK to ad…

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -20,7 +20,7 @@
         <cumulocity.clients.version>${project.version}</cumulocity.clients.version>
 
         <spring-boot-dependencies.version>2.7.17</spring-boot-dependencies.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <guava.version>32.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
         <rest-assured.version>4.5.1</rest-assured.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jaxrs.version>2.1.6</jaxrs.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <junit.version>5.8.2</junit.version>
         <logback.version>1.2.11</logback.version>


### PR DESCRIPTION
This PR is in the context of https://cumulocity.atlassian.net/browse/MTM-56693
The jetty version is updated from 9.4.51 to 9.4.53 to address    CVE: CVE-2023-44487 and CVE: CVE-2023-36478
As there was a deprecated class with the jetty update, a change in the cumulocity-agents repository was needed. 
The related agents-PR is: https://github.softwareag.com/IOTA/cumulocity-agents/pull/1320