### PR TITLE
Update .backportrc.json - use default values for urls

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,8 +5,5 @@
   "sourcePRLabels": ["was-backported"],
   "targetPRLabels": ["backport"],
   "targetBranchChoices": ["release/r1018.0.0", "release/r1017.0.0", "release/r1016.0.0", "release/r1015.0.0", "release/r1014.0.0"],
-  "gitHostname": "github.com",
-  "githubApiBaseUrlV3": "https://github.com/api/v3",
-  "githubApiBaseUrlV4": "https://github.com/api/graphql",
   "fork": false
 }


### PR DESCRIPTION
Correct invalid urls and use defaults as per https://github.com/sqren/backport/blob/main/docs/config-file-options.md#githostname
