### PR TITLE
MTM-56327 revert and deprecate default postFile methods

### DIFF
--- a/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/RestConnector.java
@@ -202,6 +202,11 @@ public class RestConnector implements RestOperations {
     }
 
     @Override
+    public <T extends ResourceRepresentation> T postFile(String path, T representation, byte[] bytes, Class<T> responseClass) {
+        return postFile(path, representation, bytes, MediaType.APPLICATION_OCTET_STREAM_TYPE, responseClass);
+    }
+
+    @Override
     public <T extends ResourceRepresentation> T postFile(String path, T representation, byte[] bytes, MediaType mediaType,
                                                          Class<T> responseClass) {
         Builder builder = getResourceBuilder(path);
@@ -211,6 +216,11 @@ public class RestConnector implements RestOperations {
         form.bodyPart(new FormDataBodyPart("file", bytes, mediaType));
         Entity<MultiPart> file = Entity.entity(form, addBoundary(form.getMediaType()));
         return parseResponseWithoutId(responseClass, builder.post(file), CREATED.getStatusCode());
+    }
+
+    @Override
+    public <T extends ResourceRepresentation> T postFileAsStream(String path, T representation, InputStream inputStream, Class<T> responseClass) {
+        return postFileAsStream(path, representation, inputStream, MediaType.APPLICATION_OCTET_STREAM_TYPE, responseClass);
     }
 
     @Override

--- a/java-client/src/main/java/com/cumulocity/sdk/client/RestOperations.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/RestOperations.java
@@ -30,8 +30,16 @@ public interface RestOperations extends AutoCloseable {
     <T extends ResourceRepresentation> T putStream(String path, MediaType mediaType, InputStream content,
                                                    Class<T> responseClass);
 
+    @Deprecated
+    <T extends ResourceRepresentation> T postFile(String path, T representation, byte[] bytes,
+                                                  Class<T> responseClass);
+
     <T extends ResourceRepresentation> T postFile(String path, T representation, byte[] bytes, MediaType mediaType,
                                                   Class<T> responseClass);
+
+    @Deprecated
+    <T extends ResourceRepresentation> T postFileAsStream(String path, T representation, InputStream inputStream,
+                                                          Class<T> responseClass);
 
     <T extends ResourceRepresentation> T postFileAsStream(String path, T representation, InputStream inputStream, MediaType mediaType,
                                                           Class<T> responseClass);

--- a/microservice/subscription/src/test/java/com/cumulocity/microservice/subscription/repository/impl/FakeCredentialsSwitchingPlatform.java
+++ b/microservice/subscription/src/test/java/com/cumulocity/microservice/subscription/repository/impl/FakeCredentialsSwitchingPlatform.java
@@ -194,7 +194,17 @@ public class FakeCredentialsSwitchingPlatform implements CredentialsSwitchingPla
             }
 
             @Override
+            public <T extends ResourceRepresentation> T postFile(String path, T representation, byte[] bytes, Class<T> responseClass) {
+                throw new UnsupportedOperationException("unsuported");
+            }
+
+            @Override
             public <T extends ResourceRepresentation> T postFile(String path, T representation, byte[] bytes, MediaType mediaType, Class<T> responseClass) {
+                throw new UnsupportedOperationException("unsuported");
+            }
+
+            @Override
+            public <T extends ResourceRepresentation> T postFileAsStream(String path, T representation, InputStream inputStream, Class<T> responseClass) {
                 throw new UnsupportedOperationException("unsuported");
             }
 


### PR DESCRIPTION
Due to backward compatibility issues had to revert methods removed in https://github.com/SoftwareAG/cumulocity-clients-java/pull/411