### PR TITLE
MTM-56899/Upgrade logback-classic and logback-core due to vulnerabilities

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -24,6 +24,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
         <rest-assured.version>4.5.1</rest-assured.version>
+	<logback.version>1.2.13</logback.version>
 
         <nexus.url>http://localhost:8080</nexus.url>
         <nexus.basePath>/nexus/content/repositories</nexus.basePath>
@@ -73,6 +74,16 @@
                 <version>${spring-boot-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -90,6 +101,16 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+	    <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+	    <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <!-- microservice libraries -->


### PR DESCRIPTION
This PR is in the context of https://cumulocity.atlassian.net/browse/MTM-56899 and addresses https://nvd.nist.gov/vuln/detail/CVE-2023-6378 .
Logback-classic and logback-core are updated to non-vulnerable versions.