### PR TITLE
Bugfix/MTM 57129/[Graft][1016] Update logback version due to security vulnerabilities

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -23,7 +23,7 @@
         <jetty.version>9.4.44.v20210927</jetty.version>
         <guava.version>31.0.1-jre</guava.version>
         <googleauth.version>1.1.1</googleauth.version>
-
+        <logback.version>1.2.13</logback.version>
         <nexus.url>http://localhost:8080</nexus.url>
         <nexus.basePath>/nexus/content/repositories</nexus.basePath>
     </properties>
@@ -64,6 +64,16 @@
                 <version>${spring-boot-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -81,6 +91,16 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <!-- microservice libraries -->


### PR DESCRIPTION
This PR is backporting https://github.com/SoftwareAG/cumulocity-clients-java/pull/423 to release r1016.0.0, and is in the context of https://cumulocity.atlassian.net/browse/MTM-57129 . It addresses https://nvd.nist.gov/vuln/detail/CVE-2023-6378 .
Logback-classic and logback-core are updated to non-vulnerable versions.