### PR TITLE
[DM-2870] After pod creation /etc/mtab symlink is missing, graft 1017

### DIFF
--- a/.jenkins/github/pre-merge.jenkinsfile
+++ b/.jenkins/github/pre-merge.jenkinsfile
@@ -183,6 +183,9 @@ def build_agents() {
         dir('cumulocity-agents') {
           stage('agents build & verify') {
             try {
+              // During the POD creation /etc/mtab symlink is removed. This might be related to this issue https://github.com/kubernetes/kubernetes/issues/96961
+              // but it never been resolved. We need /etc/mtab symlink because it resolves a file creation issue in our OPC UA unit tests. See: MTM-56794 and DM-2870
+              sh 'if [ ! -e \'/etc/mtab\' ]; then sudo ln -s ../proc/mounts /etc/mtab; fi'
               sh '.jenkins/scripts/mvn.sh package'
             } catch (e) {
               stopPipeline('Build & test agents', e)
@@ -240,7 +243,6 @@ def spinup_instance(instance) {
           booleanParam(name: 'RUN_READ_PERFORMANCE_TESTS', value: false),
           string(name: 'PURPOSE', value: 'clients-java-pre-merge-check'),
           string(name: 'DEV_TEAM', value: 'Common Infrastructure'),
-          string(name: 'LP_LIST', value: 'cep'),
           string(name: 'PROJECT', value: 'C8Y Core')
       ],
           propagate: true

--- a/.jenkins/github/pre-merge.jenkinsfile
+++ b/.jenkins/github/pre-merge.jenkinsfile
@@ -243,6 +243,7 @@ def spinup_instance(instance) {
           booleanParam(name: 'RUN_READ_PERFORMANCE_TESTS', value: false),
           string(name: 'PURPOSE', value: 'clients-java-pre-merge-check'),
           string(name: 'DEV_TEAM', value: 'Common Infrastructure'),
+          string(name: 'LP_LIST', value: 'cep'),
           string(name: 'PROJECT', value: 'C8Y Core')
       ],
           propagate: true


### PR DESCRIPTION
After pod creation `/etc/mtab symlink` is missing. This leads to a failure of some OPCUA unit tests, which are using a third party library to write a file onto the filesystem. The library first uses a native java call to get the mounted filesystems `List<UnixMountEntry> getMountEntries()` and then checks whether there is enough space the file to be created. This workaround resolves the issue creating a `/etc/mtab` symlink, if missing.