### PR TITLE
Bugfix/MTM-57129/[Graft] [y2024] Update logback version due to security vulnerabilities

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -25,6 +25,7 @@
         <googleauth.version>1.1.1</googleauth.version>
         <rest-assured.version>4.5.1</rest-assured.version>
 
+        <logback.version>1.2.13</logback.version>
         <nexus.url>http://localhost:8080</nexus.url>
         <nexus.basePath>/nexus/content/repositories</nexus.basePath>
     </properties>
@@ -73,6 +74,16 @@
                 <version>${spring-boot-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -90,6 +101,16 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
             </dependency>
 
             <!-- microservice libraries -->


### PR DESCRIPTION
This PR is backporting https://github.com/SoftwareAG/cumulocity-clients-java/pull/423 to release y2024 and is in the context of https://cumulocity.atlassian.net/browse/MTM-57129. It addresses https://nvd.nist.gov/vuln/detail/CVE-2023-6378 .
Logback-classic and logback-core are updated to non-vulnerable versions.