### PR TITLE
MTM-57614 alow to also make dependencies when running functional tests

### DIFF
--- a/.jenkins/github/functional-sdk-tests.jenkinsfile
+++ b/.jenkins/github/functional-sdk-tests.jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
           catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
             sh """\
                 .jenkins/scripts/mvn.sh verify \\
-                    --file java-client \\
+                    --projects java-client --also-make \\
                     --define 'cumulocity.host=http://${params.TEST_DOMAIN}:8111'
                """.stripIndent()
           }


### PR DESCRIPTION
Fixes error when running for non-published version:

```
[ERROR] Failed to execute goal on project java-client:
Could not resolve dependencies for project com.nsn.cumulocity.clients-java:java-client:jar:1020.127.0.2371.7.core:
The following artifacts could not be resolved: com.nsn.cumulocity.clients-java:java-client-model:jar:1020.127.0.2371.7.core, com.nsn.cumulocity.model:device-capability-model:jar:1020.127.0.2371.7.core, com.nsn.cumulocity.clients-java:java-client-model:jar:tests:1020.127.0.2371.7.core:
Could not find artifact com.nsn.cumulocity.clients-java:java-client-model:jar:1020.127.0.2371.7.core in public
```