### PR TITLE
MTM-57614 prevent building modules other than the main one when running functional tests

### DIFF
--- a/.jenkins/github/functional-sdk-tests.jenkinsfile
+++ b/.jenkins/github/functional-sdk-tests.jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
           catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
             sh """\
                 .jenkins/scripts/mvn.sh verify \\
-                    --projects java-client --also-make \\
+                    --file . --projects java-client --also-make \\
                     --define 'cumulocity.host=http://${params.TEST_DOMAIN}:8111'
                """.stripIndent()
           }


### PR DESCRIPTION
When `-f` or `--file` is not specified, then the [`.jenkins/scripts/mvn.sh`](https://github.com/SoftwareAG/cumulocity-clients-java/blob/develop/.jenkins/scripts/mvn.sh#L55) script iterates over all the submodules by default. Specifying only the main module disables this behavior and prevents the error:
```
[ERROR] [ERROR] Could not find the selected project in the reactor: java-client @ 
[ERROR] Could not find the selected project in the reactor: java-client -> [Help 1]
org.apache.maven.MavenExecutionException: Could not find the selected project in the reactor: java-client
```