### PR TITLE
Java implementation for real-time notifications

### DIFF
--- a/java-client-model/src/main/java/com/cumulocity/model/JSONBase.java
+++ b/java-client-model/src/main/java/com/cumulocity/model/JSONBase.java
@@ -1,5 +1,6 @@
 package com.cumulocity.model;
 
+import com.cumulocity.model.NotificationConverters.*;
 import com.cumulocity.model.audit.AuditChangeValueConverter;
 import org.joda.time.DateTime;
 import org.svenson.*;
@@ -72,6 +73,11 @@ public class JSONBase extends AbstractDynamicProperties {
         converters.add(new IDListTypeConverter());
         converters.add(new DateConverter());
         converters.add(new AuditChangeValueConverter());
+        converters.add(new DeletedManagedObjectConverter());
+        converters.add(new DeletedMeasurementConverter());
+        converters.add(new DeletedEventConverter());
+        converters.add(new DeletedAlarmConverter());
+        converters.add(new DeletedOperationConverter());
         return converters;
     }
 

--- a/java-client-model/src/main/java/com/cumulocity/model/JSONBase.java
+++ b/java-client-model/src/main/java/com/cumulocity/model/JSONBase.java
@@ -73,6 +73,7 @@ public class JSONBase extends AbstractDynamicProperties {
         converters.add(new IDListTypeConverter());
         converters.add(new DateConverter());
         converters.add(new AuditChangeValueConverter());
+        converters.add(new DeletedGeneralObjectConverter());
         converters.add(new DeletedManagedObjectConverter());
         converters.add(new DeletedMeasurementConverter());
         converters.add(new DeletedEventConverter());

--- a/java-client-model/src/main/java/com/cumulocity/model/NotificationConverters.java
+++ b/java-client-model/src/main/java/com/cumulocity/model/NotificationConverters.java
@@ -3,13 +3,43 @@ package com.cumulocity.model;
 import org.svenson.converter.TypeConverter;
 
 import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.AbstractExtensibleRepresentation;
 import com.cumulocity.rest.representation.alarm.AlarmRepresentation;
 import com.cumulocity.rest.representation.event.EventRepresentation;
 import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
 import com.cumulocity.rest.representation.measurement.MeasurementRepresentation;
 import com.cumulocity.rest.representation.operation.OperationRepresentation;
 
+/**
+ * The converter classes contained in this class are used by Svenson
+ * for JSON conversion of real-time notification messages to
+ * {@link com.cumulocity.rest.representation.notification.NotificationRepresentation
+ * NotificationRepresentation}s.
+ * The conversion implemented here is needed for notifications on
+ * {@code DELETE} operations. In these cases, just a string denoting the ID
+ * of the deleted object is transferred as notification message data attribute.
+ * The provided converters wrap such IDs into objects of the desired type.
+ */
 public class NotificationConverters {
+
+    public static class DeletedGeneralObjectConverter implements TypeConverter {
+
+        @Override
+        public Object fromJSON(Object o) {
+            if (o instanceof String) {
+                AbstractExtensibleRepresentation wrapper = new AbstractExtensibleRepresentation();
+                wrapper.set(new GId((String)o));
+                o = wrapper;
+            }
+            return o;
+        }
+
+        @Override
+        public Object toJSON(Object o) { // not needed at all
+            return o;
+        }
+
+    }
 
     public static class DeletedManagedObjectConverter implements TypeConverter {
 

--- a/java-client-model/src/main/java/com/cumulocity/model/NotificationConverters.java
+++ b/java-client-model/src/main/java/com/cumulocity/model/NotificationConverters.java
@@ -1,0 +1,109 @@
+package com.cumulocity.model;
+
+import org.svenson.converter.TypeConverter;
+
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.alarm.AlarmRepresentation;
+import com.cumulocity.rest.representation.event.EventRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.rest.representation.measurement.MeasurementRepresentation;
+import com.cumulocity.rest.representation.operation.OperationRepresentation;
+
+public class NotificationConverters {
+
+    public static class DeletedManagedObjectConverter implements TypeConverter {
+
+        @Override
+        public Object fromJSON(Object o) {
+            if (o instanceof String) {
+                ManagedObjectRepresentation wrapper = new ManagedObjectRepresentation();
+                wrapper.set(new GId((String)o));
+                o = wrapper;
+            }
+            return o;
+        }
+
+        @Override
+        public Object toJSON(Object o) { // not needed at all
+            return o;
+        }
+
+    }
+
+    public static class DeletedMeasurementConverter implements TypeConverter {
+
+        @Override
+        public Object fromJSON(Object o) {
+            if (o instanceof String) {
+                MeasurementRepresentation wrapper = new MeasurementRepresentation();
+                wrapper.set(new GId((String)o));
+                o = wrapper;
+            }
+            return o;
+        }
+
+        @Override
+        public Object toJSON(Object o) { // not needed at all
+            return o;
+        }
+
+    }
+
+    public static class DeletedEventConverter implements TypeConverter {
+
+        @Override
+        public Object fromJSON(Object o) {
+            if (o instanceof String) {
+                EventRepresentation wrapper = new EventRepresentation();
+                wrapper.set(new GId((String)o));
+                o = wrapper;
+            }
+            return o;
+        }
+
+        @Override
+        public Object toJSON(Object o) { // not needed at all
+            return o;
+        }
+
+    }
+
+    public static class DeletedAlarmConverter implements TypeConverter {
+
+        @Override
+        public Object fromJSON(Object o) {
+            if (o instanceof String) {
+                AlarmRepresentation wrapper = new AlarmRepresentation();
+                wrapper.set(new GId((String)o));
+                o = wrapper;
+            }
+            return o;
+        }
+
+        @Override
+        public Object toJSON(Object o) { // not needed at all
+            return o;
+        }
+
+    }
+
+    public static class DeletedOperationConverter implements TypeConverter {
+
+        @Override
+        public Object fromJSON(Object o) {
+            if (o instanceof String) {
+                OperationRepresentation wrapper = new OperationRepresentation();
+                wrapper.set(new GId((String)o));
+                o = wrapper;
+            }
+            return o;
+        }
+
+        @Override
+        public Object toJSON(Object o) { // not needed at all
+            return o;
+        }
+
+    }
+
+}

--- a/java-client-model/src/main/java/com/cumulocity/rest/representation/notification/NotificationRepresentation.java
+++ b/java-client-model/src/main/java/com/cumulocity/rest/representation/notification/NotificationRepresentation.java
@@ -223,6 +223,27 @@ public class NotificationRepresentation<T extends AbstractExtensibleRepresentati
     }
 
     /**
+     * This class exists for technical purpose and is used in cases
+     * where real-time notifications of any type are expected,
+     * but using Generics as with
+     * {@code NotificationRepresentation<AbstractExtensibleRepresentation>}
+     * is unsuitable.
+     *
+     * @see NotificationRepresentation
+     */
+    public static class GeneralNotificationRepresentation
+            extends NotificationRepresentation<AbstractExtensibleRepresentation> {
+
+        @Override
+        @JSONProperty
+        @JSONConverter(type = DeletedGeneralObjectConverter.class)
+        public AbstractExtensibleRepresentation getData() {
+            return super.getData();
+        }
+
+    }
+
+    /**
      * This class is the Java representation of real-time notifications for
      * {@linkplain ManagedObjectRepresentation Managed Objects}
      * returned by the real-time notification API.

--- a/java-client-model/src/main/java/com/cumulocity/rest/representation/notification/NotificationRepresentation.java
+++ b/java-client-model/src/main/java/com/cumulocity/rest/representation/notification/NotificationRepresentation.java
@@ -1,0 +1,320 @@
+package com.cumulocity.rest.representation.notification;
+
+import org.svenson.JSON;
+import org.svenson.JSONProperty;
+import org.svenson.JSONable;
+import org.svenson.converter.JSONConverter;
+
+import com.cumulocity.model.NotificationConverters.*;
+import com.cumulocity.model.JSONBase;
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.rest.representation.AbstractExtensibleRepresentation;
+import com.cumulocity.rest.representation.alarm.AlarmRepresentation;
+import com.cumulocity.rest.representation.event.EventRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.rest.representation.measurement.MeasurementRepresentation;
+import com.cumulocity.rest.representation.operation.OperationRepresentation;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This class is the Java representation of objects returned by the real-time
+ * notifications API of Cumulocity IoT.
+ *
+ * For each type of domain model objects (Measurements, Events, etc.) that supports
+ * real-time notifications there is a specific subclass of this class available:
+ * <ul>
+ * <li>{@link AlarmNotificationRepresentation}</li>
+ * <li>{@link EventNotificationRepresentation}</li>
+ * <li>{@link ManagedObjectNotificationRepresentation}</li>
+ * <li>{@link MeasurementNotificationRepresentation}</li>
+ * <li>{@link OperationNotificationRepresentation}</li>
+ * </ul>
+ *
+ * Each object returned as real-time notification has two attributes:
+ * <dl>
+ * <dt>{@code realtimeAction}</dt>
+ * <dd>The action can be one of {@link Action#CREATE CREATE}, {@link Action#UPDATE UPDATE},
+ *     or {@link Action#DELETE DELETE}.</dd>
+ * <dt>{@code data}</dt>
+ * <dd>The data contains the actual object which this notification is about.
+ *     It is an object from Cumulocity's domain model (e.&thinsp;g. an Alarm).
+ *     However, in case of a {@code DELETE} action, the data only contains
+ *     the ID of the deleted object. Thus this Java representation exposes
+ *     two separate accessors for proper type handling:
+ *     {@link #getData()} and {@link #getDeletedDataId()}</dd>
+ * </dl>
+ *
+ * @param <T>  the type of domain model object for which notifications are created
+ *     (e.&thinsp;g. {@link AlarmRepresentation})
+ */
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class NotificationRepresentation<T extends AbstractExtensibleRepresentation>
+        implements JSONable {
+
+    /**
+     * Enumeration of the possible action types reported in real-time notifications.
+     * <ul>
+     * <li>{@link #CREATE}</li>
+     * <li>{@link #UPDATE}</li>
+     * <li>{@link #DELETE}</li>
+     * </ul>
+     */
+    public enum Action {
+        /** The {@code CREATE} action. */
+        CREATE,
+        /** The {@code UPDATE} action. */
+        UPDATE,
+        /**
+         * The {@code DELETE} action is special in the sense that a real-time
+         * notification for this action does not contain a data object,
+         * but only the ID of the deleted object as
+         * {@link NotificationRepresentation#getData() data} attribute.
+         */
+        DELETE;
+    }
+
+    private static final JSON JSON_GENERATOR = JSONBase.getJSONGenerator();
+
+    /**
+     * -- SETTER --
+     * Setter for the {@code realtimeAction} attribute of this real-time notification object.
+     * This method should be rarely needed by users because notification objects
+     * are usually created by the SDK (not by users) and consumed by users.
+     *
+     * @param realtimeAction  the {@link Action} which is reported by this
+     *     real-time notification
+     *
+     * -- GETTER --
+     * Getter for the {@code realtimeAction} attribute of this real-time notification object.
+     *
+     * @return the {@link Action} which is reported by this real-time notification
+     */
+    @Setter
+    @Getter(onMethod_=@JSONProperty)
+    @EqualsAndHashCode.Include
+    private Action realtimeAction;
+    
+    private T data; // Usually of type T, but if realtimeAction is DELETE,
+                    // the JSON 'data' attribute is just a string holding the ID
+                    // of the deleted object. We store the latter as dataId.
+    private GId dataId;
+
+    /**
+     * Setter for the {@code data} attribute of this real-time notification object.
+     * This method should be rarely needed by users because notification objects
+     * are usually created by the SDK (not by users) and consumed by users.
+     * However, if users want to construct a notification for a {@link Action#DELETE DELETE}
+     * action, the method {@link #setDeletedDataId(String)} or {@link #setDeletedDataId(GId)}
+     * should be used instead of this method.
+     *
+     * @param data  the domain model object (e.&thinsp;g. an Alarm)
+     *     which this notification is about
+     */
+    public void setData(T data) {
+        this.data = data;
+        if (data != null)
+            this.dataId = data.get(GId.class); // Users should set this ID with setDeletedDataId()
+                // and not via setData(), but this step is needed here for the JSON parsing process.
+    }
+
+    /**
+     * Getter for the {@code data} attribute of this real-time notification object.
+     *
+     * @return the domain model object (e.&thinsp;g. an Alarm) transported by
+     *     this notification object
+     * @throws IllegalStateException  if this method is used on a
+     *     {@link Action#DELETE DELETE} notification
+     */
+    public T getData() { // Note: This method must be overridden in appropriate subclasses
+                         // for proper JSON parsing because if we annotated @JSONProperty
+                         // here, Svenson's logic would resolve to the base type
+                         // AbstractExtensibleRepresentation, not to type T,
+                         // due to type erasure.
+        if (Action.CREATE.equals(realtimeAction) || Action.UPDATE.equals(realtimeAction))
+            return data;
+        else
+            throw new IllegalStateException("This method must only be used if \"realtimeAction\" is \"CREATE\" or \"UPDATE\".");
+    }
+
+    /**
+     * Setter for the {@code data} attribute of this real-time notification object
+     * in case of a {@link Action#DELETE DELETE} action.
+     * This method should be rarely needed by users because notification objects
+     * are usually created by the SDK (not by users) and consumed by users.
+     *
+     * @param id  the ID of the deleted object
+     * @throws IllegalStateException  if this method is <i>not</i> used on a
+     *     {@link Action#DELETE DELETE} notification
+     */
+    public void setDeletedDataId(String id) {
+        setDeletedDataId(new GId(id));
+    }
+
+    /**
+     * Setter for the {@code data} attribute of this real-time notification object
+     * in case of a {@link Action#DELETE DELETE} action.
+     * This method should be rarely needed by users because notification objects
+     * are usually created by the SDK (not by users) and consumed by users.
+     *
+     * @param id  the ID of the deleted object
+     * @throws IllegalStateException  if this method is <i>not</i> used on a
+     *     {@link Action#DELETE DELETE} notification
+     */
+    public void setDeletedDataId(GId id) {
+        if (Action.DELETE.equals(realtimeAction))
+            this.dataId = id;
+        else
+            throw new IllegalStateException("This method must only be used if \"realtimeAction\" is \"DELETE\".");
+    }
+
+    /**
+     * Getter for the {@code data} attribute of this real-time notification object
+     * in case of a {@link Action#DELETE DELETE} action.
+     *
+     * @return the ID of the deleted object transported by this notification object
+     * @throws IllegalStateException  if this method is <i>not</i> used on a
+     *     {@link Action#DELETE DELETE} notification
+     */
+    @JSONProperty(ignore = true)
+    public GId getDeletedDataId() {
+        if (Action.DELETE.equals(realtimeAction))
+            return dataId;
+        else
+            throw new IllegalStateException("This method must only be used if \"realtimeAction\" is \"DELETE\".");
+    }
+
+    /**
+     * Serializes this notification object into a JSON object equivalent to the JSON
+     * notification objects generated by Cumulocity's real-time notification API.
+     * Depending on the {@linkplain #getRealtimeAction() real-time action}, the
+     * {@code data} attribute of the JSON object is populated with different content:
+     * <ul>
+     * <li>In case of a {@link Action#CREATE CREATE} or {@link Action#UPDATE UPDATE}
+     *     action, the {@linkplain #getData() data object} is serialized into the
+     *     {@code data} attribute.</li>
+     * <li>In case of a {@link Action#DELETE DELETE} action, the
+     *     {@linkplain #getDeletedDataId() ID of the deleted object}
+     *     is serialized into the {@code data} attribute.</li>
+     * </ul>
+     */
+    @Override
+    public String toJSON() {
+        return "{\"realtimeAction\":" + JSON_GENERATOR.forValue(realtimeAction)
+                + ",\"data\":" + JSON_GENERATOR.forValue(getDataOrId()) + "}";
+    }
+
+    /**
+     * Converts this notification object to a JSON string as returned by {@link #toJSON()}.
+     */
+    @Override
+    public String toString() {
+        return toJSON();
+    }
+
+    @EqualsAndHashCode.Include
+    private Object getDataOrId() {
+        return Action.DELETE.equals(realtimeAction)
+                ? dataId // use ID in case of DELETE action
+                : data; // use data object in case of all other actions (CREATE and UPDATE)
+                        // and in case of realtimeAction == null
+    }
+
+    /**
+     * This class is the Java representation of real-time notifications for
+     * {@linkplain ManagedObjectRepresentation Managed Objects}
+     * returned by the real-time notification API.
+     *
+     * @see NotificationRepresentation
+     */
+    public static class ManagedObjectNotificationRepresentation
+            extends NotificationRepresentation<ManagedObjectRepresentation> {
+
+        @Override
+        @JSONProperty
+        @JSONConverter(type = DeletedManagedObjectConverter.class)
+        public ManagedObjectRepresentation getData() {
+            return super.getData();
+        }
+
+    }
+
+    /**
+     * This class is the Java representation of real-time notifications for
+     * {@linkplain MeasurementRepresentation Measurements}
+     * returned by the real-time notification API.
+     *
+     * @see NotificationRepresentation
+     */
+    public static class MeasurementNotificationRepresentation
+            extends NotificationRepresentation<MeasurementRepresentation> {
+
+        @Override
+        @JSONProperty
+        @JSONConverter(type = DeletedMeasurementConverter.class)
+        public MeasurementRepresentation getData() {
+            return super.getData();
+        }
+
+    }
+
+    /**
+     * This class is the Java representation of real-time notifications for
+     * {@linkplain EventRepresentation Events}
+     * returned by the real-time notification API.
+     *
+     * @see NotificationRepresentation
+     */
+    public static class EventNotificationRepresentation
+            extends NotificationRepresentation<EventRepresentation> {
+
+        @Override
+        @JSONProperty
+        @JSONConverter(type = DeletedEventConverter.class)
+        public EventRepresentation getData() {
+            return super.getData();
+        }
+
+    }
+
+    /**
+     * This class is the Java representation of real-time notifications for
+     * {@linkplain AlarmRepresentation Alarms}
+     * returned by the real-time notification API.
+     *
+     * @see NotificationRepresentation
+     */
+    public static class AlarmNotificationRepresentation
+            extends NotificationRepresentation<AlarmRepresentation> {
+
+        @Override
+        @JSONProperty
+        @JSONConverter(type = DeletedAlarmConverter.class)
+        public AlarmRepresentation getData() {
+            return super.getData();
+        }
+
+    }
+
+    /**
+     * This class is the Java representation of real-time notifications for
+     * {@linkplain OperationRepresentation Operations}
+     * returned by the real-time notification API.
+     *
+     * @see NotificationRepresentation
+     */
+    public static class OperationNotificationRepresentation
+            extends NotificationRepresentation<OperationRepresentation> {
+
+        @Override
+        @JSONProperty
+        @JSONConverter(type = DeletedOperationConverter.class)
+        public OperationRepresentation getData() {
+            return super.getData();
+        }
+
+    }
+
+}

--- a/java-client-model/src/test/java/com/cumulocity/model/NotificationConversionTest.java
+++ b/java-client-model/src/test/java/com/cumulocity/model/NotificationConversionTest.java
@@ -1,5 +1,7 @@
 package com.cumulocity.model;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -18,39 +20,67 @@ public class NotificationConversionTest {
 
     private static final JSONParser PARSER = JSONBase.getJSONParser();
 
-    public <T extends NotificationRepresentation<?>> void jsonRoundtrip(String json, Class<T> type) {
+    public void shallowJsonRoundtripCheck(String json) {
+        GeneralNotificationRepresentation parsed =
+                PARSER.parse(GeneralNotificationRepresentation.class, json);
+        String json2 = parsed.toJSON(); // This one might differ from the input JSON object
+                                        // because the input might not be in the canonical
+                                        // form (whitespace normalization).
+
+        // check for equality in terms of JSON structure
+        assertEquals(PARSER.parse(json), PARSER.parse(json2));
+        // Note: We can't compare objects of type GeneralNotificationRepresentation
+        // because the underlying AbstractExtensibleRepresentation does not have
+        // a semantic "equals" method.
+    }
+
+    public <T extends NotificationRepresentation<?>> void semanticJsonRoundtripCheck(String json, Class<T> type) {
         T parsed = PARSER.parse(type, json);
-        String json2 = parsed.toJSON(); // might differ from input JSON object because
-                                        // input might not be in the canonical form
+        String json2 = parsed.toJSON(); // This one might differ from the input JSON object
+                                        // because the input might not be in the canonical
+                                        // form (whitespace, but also date-time strings,
+                                        // and maybe other things).
         T parsed2 = PARSER.parse(type, json2);
+
+        // check for equality in terms of target object type
         assertEquals(parsed, parsed2);
     }
 
     @Test
     public void testOperationNotification() {
-        jsonRoundtrip("{ \"realtimeAction\": \"CREATE\", \"data\": { \"id\": \"0815\","
-                + "\"self\": \"https://TENANT.DOMAIN/devicecontrol/operation/0815\","
-                + "\"creationTime\": \"2019-12-17T09:46:45.435+01:00\", \"deviceId\": \"42\","
-                + "\"deviceName\": \"My Device\", \"status\": \"PENDING\", \"time\":"
-                + "\"2020-01-01T00:00:00+01:00\", \"c8y_Restart\": {} } }",
-                OperationNotificationRepresentation.class);
-    }
-    
-    @Test
-    public void testDeletedOperationNotification() {
-        jsonRoundtrip("{ \"realtimeAction\": \"DELETE\", \"data\": \"0815\" }",
+        String operationNotification =
+                "{ \"realtimeAction\": \"CREATE\", \"data\": { \"id\": \"0815\", "
+                + "\"self\": \"https://TENANT.DOMAIN/devicecontrol/operation/0815\", "
+                + "\"creationTime\": \"2019-12-17T09:46:45.435+01:00\", \"deviceId\": "
+                + "\"42\", \"deviceName\": \"My Device\", \"status\": \"PENDING\", "
+                + "\"time\": \"2020-01-01T00:00:00+01:00\", \"c8y_Restart\": {} } }";
+        shallowJsonRoundtripCheck(operationNotification);
+        semanticJsonRoundtripCheck(operationNotification,
                 OperationNotificationRepresentation.class);
     }
 
     @Test
-    public void testEventNotificationToJson() {
-        jsonRoundtrip("{ \"realtimeAction\": \"CREATE\", \"data\": { \"id\": \"1234\","
-                + "\"self\": \"https://TENANT.DOMAIN/event/events/1234\", \"creationTime\":"
-                + "\"2020-01-01T00:00:01.184+01:00\", \"lastUpdated\":"
-                + "\"2020-01-01T00:00:01.184+01:00\", \"source\": { \"id\": \"42\","
-                + "\"self\": \"https://TENANT.DOMAIN/inventory/managedObjects/42\" },"
-                + "\"type\": \"CustomEvent\", \"time\": \"2020-01-01T00:00:00+01:00\","
-                + "\"text\": \"This even occurred.\" } }",
+    public void testDeletedOperationNotification() {
+        String deletedOperationNotification =
+                "{ \"realtimeAction\": \"DELETE\", \"data\": \"0815\" }";
+        shallowJsonRoundtripCheck(deletedOperationNotification);
+        semanticJsonRoundtripCheck(deletedOperationNotification,
+                OperationNotificationRepresentation.class);
+    }
+
+    @Test
+    public void testEventNotification() {
+        String eventNotification =
+                "{ \"realtimeAction\": \"CREATE\", \"data\": { \"id\": \"1234\", "
+                + "\"self\": \"https://TENANT.DOMAIN/event/events/1234\", "
+                + "\"creationTime\": \"2020-01-01T00:00:01.184+01:00\", "
+                + "\"lastUpdated\": \"2020-01-01T00:00:01.184+01:00\", "
+                + "\"source\": { \"id\": \"42\", \"self\": "
+                + "\"https://TENANT.DOMAIN/inventory/managedObjects/42\" }, "
+                + "\"type\": \"CustomEvent\", \"time\": \"2020-01-01T00:00:00+01:00\", "
+                + "\"text\": \"This event occurred.\" } }";
+        shallowJsonRoundtripCheck(eventNotification);
+        semanticJsonRoundtripCheck(eventNotification,
                 EventNotificationRepresentation.class);
     }
 

--- a/java-client-model/src/test/java/com/cumulocity/model/NotificationConversionTest.java
+++ b/java-client-model/src/test/java/com/cumulocity/model/NotificationConversionTest.java
@@ -1,0 +1,57 @@
+package com.cumulocity.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.svenson.JSONParser;
+
+import com.cumulocity.model.JSONBase;
+import com.cumulocity.rest.representation.alarm.AlarmRepresentation;
+import com.cumulocity.rest.representation.event.EventRepresentation;
+import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
+import com.cumulocity.rest.representation.measurement.MeasurementRepresentation;
+import com.cumulocity.rest.representation.operation.OperationRepresentation;
+import com.cumulocity.rest.representation.notification.NotificationRepresentation;
+import com.cumulocity.rest.representation.notification.NotificationRepresentation.*;
+
+public class NotificationConversionTest {
+
+    private static final JSONParser PARSER = JSONBase.getJSONParser();
+
+    public <T extends NotificationRepresentation<?>> void jsonRoundtrip(String json, Class<T> type) {
+        T parsed = PARSER.parse(type, json);
+        String json2 = parsed.toJSON(); // might differ from input JSON object because
+                                        // input might not be in the canonical form
+        T parsed2 = PARSER.parse(type, json2);
+        assertEquals(parsed, parsed2);
+    }
+
+    @Test
+    public void testOperationNotification() {
+        jsonRoundtrip("{ \"realtimeAction\": \"CREATE\", \"data\": { \"id\": \"0815\","
+                + "\"self\": \"https://TENANT.DOMAIN/devicecontrol/operation/0815\","
+                + "\"creationTime\": \"2019-12-17T09:46:45.435+01:00\", \"deviceId\": \"42\","
+                + "\"deviceName\": \"My Device\", \"status\": \"PENDING\", \"time\":"
+                + "\"2020-01-01T00:00:00+01:00\", \"c8y_Restart\": {} } }",
+                OperationNotificationRepresentation.class);
+    }
+    
+    @Test
+    public void testDeletedOperationNotification() {
+        jsonRoundtrip("{ \"realtimeAction\": \"DELETE\", \"data\": \"0815\" }",
+                OperationNotificationRepresentation.class);
+    }
+
+    @Test
+    public void testEventNotificationToJson() {
+        jsonRoundtrip("{ \"realtimeAction\": \"CREATE\", \"data\": { \"id\": \"1234\","
+                + "\"self\": \"https://TENANT.DOMAIN/event/events/1234\", \"creationTime\":"
+                + "\"2020-01-01T00:00:01.184+01:00\", \"lastUpdated\":"
+                + "\"2020-01-01T00:00:01.184+01:00\", \"source\": { \"id\": \"42\","
+                + "\"self\": \"https://TENANT.DOMAIN/inventory/managedObjects/42\" },"
+                + "\"type\": \"CustomEvent\", \"time\": \"2020-01-01T00:00:00+01:00\","
+                + "\"text\": \"This even occurred.\" } }",
+                EventNotificationRepresentation.class);
+    }
+
+}

--- a/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/InventoryRealtimeDeleteAwareNotificationsSubscriber.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/InventoryRealtimeDeleteAwareNotificationsSubscriber.java
@@ -23,6 +23,10 @@ import com.cumulocity.sdk.client.PlatformParameters;
 import com.cumulocity.sdk.client.SDKException;
 import com.cumulocity.sdk.client.notification.*;
 
+/**
+ * @deprecated Use {@link com.cumulocity.sdk.client.notification.NotificationSubscriberProducer} instead.
+ */
+@Deprecated
 public class InventoryRealtimeDeleteAwareNotificationsSubscriber implements Subscriber<String, ManagedObjectDeleteAwareNotification> {
 
     private static final String REALTIME_NOTIFICATIONS_URL = "notification/realtime";

--- a/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/InventoryRealtimeNotificationsSubscriber.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/InventoryRealtimeNotificationsSubscriber.java
@@ -24,9 +24,7 @@ import com.cumulocity.sdk.client.SDKException;
 import com.cumulocity.sdk.client.notification.*;
 
 /**
- * This subscriber does not support realtime DELETE actions.
- * Please use instead InventoryRealtimeDeleteAwareNotificationsSubscriber.java
- *
+ * @deprecated Use {@link com.cumulocity.sdk.client.notification.NotificationSubscriberProducer} instead.
  */
 @Deprecated
 public class InventoryRealtimeNotificationsSubscriber implements Subscriber<String, ManagedObjectNotification> {

--- a/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/ManagedObjectDeleteAwareNotification.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/ManagedObjectDeleteAwareNotification.java
@@ -5,7 +5,11 @@ package com.cumulocity.sdk.client.cep.notification;
  * however DELETE notification has just String value. 
  * That is why data has to be of type Object to support both.
  *
+ * @deprecated This class is superseded by {@link
+ * com.cumulocity.rest.representation.notification.NotificationRepresentation.ManagedObjectNotificationRepresentation}.
+ * Use it based on {@link com.cumulocity.sdk.client.notification.NotificationSubscriberProducer}.
  */
+@Deprecated
 public class ManagedObjectDeleteAwareNotification {
     
     public ManagedObjectDeleteAwareNotification() {}

--- a/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/ManagedObjectNotification.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/cep/notification/ManagedObjectNotification.java
@@ -2,6 +2,12 @@ package com.cumulocity.sdk.client.cep.notification;
 
 import com.cumulocity.rest.representation.inventory.ManagedObjectRepresentation;
 
+/**
+ * @deprecated This class is superseded by {@link
+ * com.cumulocity.rest.representation.notification.NotificationRepresentation.ManagedObjectNotificationRepresentation}.
+ * Use it based on {@link com.cumulocity.sdk.client.notification.NotificationSubscriberProducer}.
+ */
+@Deprecated
 public class ManagedObjectNotification {
     
     public ManagedObjectNotification() {}

--- a/java-client/src/main/java/com/cumulocity/sdk/client/devicecontrol/notification/OperationNotificationSubscriber.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/devicecontrol/notification/OperationNotificationSubscriber.java
@@ -6,6 +6,10 @@ import com.cumulocity.sdk.client.PlatformParameters;
 import com.cumulocity.sdk.client.SDKException;
 import com.cumulocity.sdk.client.notification.*;
 
+/**
+ * @deprecated Use {@link com.cumulocity.sdk.client.notification.NotificationSubscriberProducer} instead.
+ */
+@Deprecated
 public class OperationNotificationSubscriber implements Subscriber<GId, OperationRepresentation> {
     public static final String DEVICE_CONTROL_NOTIFICATIONS_URL = "notification/operations";
 

--- a/java-client/src/main/java/com/cumulocity/sdk/client/notification/NotificationSubscriberProducer.java
+++ b/java-client/src/main/java/com/cumulocity/sdk/client/notification/NotificationSubscriberProducer.java
@@ -1,0 +1,143 @@
+package com.cumulocity.sdk.client.notification;
+
+import java.util.HashMap;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import com.cumulocity.model.idtype.GId;
+import com.cumulocity.sdk.client.PlatformParameters;
+import com.cumulocity.rest.representation.notification.NotificationRepresentation;
+import com.cumulocity.rest.representation.notification.NotificationRepresentation.*;
+import com.cumulocity.sdk.client.notification.Subscriber;
+import com.cumulocity.sdk.client.notification.SubscriberBuilder;
+
+/**
+ * Utility class for creating {@linkplain Subscriber subscribers} to the real-time
+ * notification API.
+ *
+ * This class is used as follows (example):
+ * <pre>{@code
+ * // 'parameters' object of type PlatformParameters must be provided
+ * NotificationSubscriberProducer producer = new NotificationSubscriberProducer(parameters);
+ * producer.getSubscriber(Endpoint.RealtimeNotifications, AlarmNotificationRepresentation.class)
+ * .subscribe(new GId("*"), new SubscriptionListener<>() { ... });
+ * }</pre>
+ *
+ * When implementing a microservice, an instance of this class can also be obtained
+ * as autowired bean:
+ * <pre>{@code
+ * @Autowired
+ * private NotificationSubscriberProducer producer;
+ * }</pre>
+ * With this setup, a bean instance that uses the correct platform parameters is
+ * automatically provided depending on the context (tenant scope or user scope)
+ * where it is used.
+ */
+public class NotificationSubscriberProducer {
+
+    /**
+     * Enumeration of the available real-time notification endpoints.
+     * <ul>
+     * <li>{@link #RealtimeNotifications}</li>
+     * <li>{@link #OperationNotifications}</li>
+     * </ul>
+     */
+    public enum Endpoint {
+        /**
+         * Generic real-time notification endpoint.
+         * This endpoint is usable for receiving notifications for any type of
+         * domain model objects (Measurements, Events, etc.) that supports
+         * real-time notifications.
+         */
+        RealtimeNotifications("notification/realtime"),
+        /**
+         * Special real-time notification endpoint for Operations.
+         * Use this endpoint for receiving operations for Agents (i.&thinsp;e.
+         * Managed Objects having a {@code com_cumulocity_model_Agent} fragment).
+         * For receiving operations for regular Devices (having a {@code c8y_IsDevice}
+         * fragment), use the {@link #RealtimeNotifications} endpoint instead.
+         */
+        OperationNotifications("notification/operations");
+
+        /**
+         * The URL path of this endpoint.
+         */
+        public final String path;
+
+        Endpoint(String path) {
+            this.path = path;
+        }
+    }
+
+    private static final HashMap<
+            ImmutablePair<Endpoint, Class<? extends NotificationRepresentation<?>>>,
+            String /*subscriptionBase*/>
+            subscriptionBaseMap = new HashMap<>();
+    static {
+        subscriptionBaseMap.put(
+                new ImmutablePair<>(Endpoint.RealtimeNotifications, ManagedObjectNotificationRepresentation.class),
+                "/managedobjects/");
+        subscriptionBaseMap.put(
+                new ImmutablePair<>(Endpoint.RealtimeNotifications, MeasurementNotificationRepresentation.class),
+                "/measurements/");
+        subscriptionBaseMap.put(
+                new ImmutablePair<>(Endpoint.RealtimeNotifications, EventNotificationRepresentation.class),
+                "/events/");
+        subscriptionBaseMap.put(
+                new ImmutablePair<>(Endpoint.RealtimeNotifications, AlarmNotificationRepresentation.class),
+                "/alarms/");
+        subscriptionBaseMap.put(
+                new ImmutablePair<>(Endpoint.RealtimeNotifications, OperationNotificationRepresentation.class),
+                "/operations/");
+        subscriptionBaseMap.put(
+                new ImmutablePair<>(Endpoint.OperationNotifications, OperationNotificationRepresentation.class),
+                "/");
+    }
+
+    private final PlatformParameters parameters;
+
+    /**
+     * The constructor of this class.
+     *
+     * @param parameters  the information needed for accessing the real-time
+     * notification API (tenant address, credentials, etc.) 
+     */
+    public NotificationSubscriberProducer(PlatformParameters parameters) {
+        this.parameters = parameters;
+    }
+
+    /**
+     * Create a {@link Subscriber} to the given endpoint for receiving real-time
+     * notifications of the given data type.
+     *
+     * The data type depends on the type of domain model objects for which
+     * notifications shall be received. Use the following types:
+     * <ul>
+     * <li>{@link AlarmNotificationRepresentation} for notifications on Alarms</li>
+     * <li>{@link EventNotificationRepresentation} for notifications on Events</li>
+     * <li>{@link ManagedObjectNotificationRepresentation} for notifications on Managed Objects</li>
+     * <li>{@link MeasurementNotificationRepresentation} for notifications on Measurements</li>
+     * <li>{@link OperationNotificationRepresentation} for notifications on Operations</li>
+     * </ul>
+     *
+     * @param <T>  the desired data type as indicated by the {@code type} parameter
+     * @param endpoint  the desired real-time notification endpoint
+     * @param type  the class of the desired data type
+     * @return a subscriber with the specified configuration
+     */
+    public <T extends NotificationRepresentation<?>>
+            Subscriber<GId, T> getSubscriber(Endpoint endpoint, Class<T> type) {
+
+        String subscriptionBase = subscriptionBaseMap.get(new ImmutablePair<>(endpoint, type));
+        if (subscriptionBase == null)
+            throw new IllegalArgumentException("Invalid combination of endpoint and type.");
+        return new SubscriberBuilder<GId, T>()
+                .withParameters(parameters)
+                .withEndpoint(endpoint.path)
+                .withSubscriptionNameResolver(id -> subscriptionBase + id.getValue())
+                .withDataType(type)
+                .withMessageDeliveryAcknowlage(true)
+                .build();
+    }
+
+}

--- a/microservice/api/src/main/java/com/cumulocity/microservice/api/CumulocityClientFeature.java
+++ b/microservice/api/src/main/java/com/cumulocity/microservice/api/CumulocityClientFeature.java
@@ -21,6 +21,7 @@ import com.cumulocity.sdk.client.inventory.InventoryApi;
 import com.cumulocity.sdk.client.measurement.MeasurementApi;
 import com.cumulocity.sdk.client.messaging.notifications.NotificationSubscriptionApi;
 import com.cumulocity.sdk.client.messaging.notifications.TokenApi;
+import com.cumulocity.sdk.client.notification.NotificationSubscriberProducer;
 import com.cumulocity.sdk.client.option.SystemOptionApi;
 import com.cumulocity.sdk.client.option.TenantOptionApi;
 import com.cumulocity.sdk.client.user.UserApi;
@@ -205,6 +206,13 @@ public class CumulocityClientFeature {
             return delegate.getNotificationSubscriptionApi();
         }
 
+        @Primary
+        @TenantScope
+        @Bean(name = {"notificationSubscriberProducer", "tenantNotificationSubscriberProducer"})
+        public NotificationSubscriberProducer getNotificationSubscriberProducer() {
+            return new NotificationSubscriberProducer(delegate);
+        }
+
         @Override
         @PreDestroy
         public void close() {
@@ -345,6 +353,12 @@ public class CumulocityClientFeature {
         @Bean(name = "userNotificationSubscriptionApi")
         public NotificationSubscriptionApi getNotificationSubscriptionApi() throws SDKException {
             return delegate.getNotificationSubscriptionApi();
+        }
+
+        @UserScope
+        @Bean(name = "userNotificationSubscriberProducer")
+        public NotificationSubscriberProducer getNotificationSubscriberProducer() {
+            return new NotificationSubscriberProducer(delegate);
         }
 
         @Override


### PR DESCRIPTION
This patch provides the tools which enable users to handle real-time notifications easily from within their Java applications. The patch

- covers all types of domain model objects that support real-time notifications,
- covers all rea-time notification endpoints,
- provides proper Java representations for the involved notification objects (including conversion to/from JSON based on the Svenson library generally used for JSON handling in the Java SDK),
- can handle DELETE operations while not losing type information for CREATE/UPDATE notifications,
- includes some unit tests,
- is easy to use, and
- has appropriate documentation.

See also internal ticket IOT-19410.