### PR TITLE
#noissue update backport-github-action

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -16,7 +16,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v8.9.7
+        uses: sqren/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: auto-backport-to-


### PR DESCRIPTION
[This](https://github.com/sorenlouv/backport/pull/493) got finally merged so we can update backport-action to [9.5.1](https://github.com/sorenlouv/backport-github-action/pull/121)
With this change we will be able to backport PR with >1 commit.