### PR TITLE
Set skipRC flag for SDK component

### DIFF
--- a/build-descriptor/java-sdk.json.j2
+++ b/build-descriptor/java-sdk.json.j2
@@ -1,6 +1,7 @@
 {
   "name": "java-sdk",
   "version": "{{ version }}",
+  "skipRC": true,
   "artifacts": [
     {
       "name": "snmp-mib-parser",


### PR DESCRIPTION
We don't need Release Candidate approval for SDK since it has automated compliance.